### PR TITLE
Order ister gui options

### DIFF
--- a/ister_gui.py
+++ b/ister_gui.py
@@ -757,7 +757,7 @@ class TelemetryDisclosure(ProcessStep):
 class StartInstaller(ProcessStep):
     """UI to select automatic or manual installation"""
     def handler(self, config):
-        choices = u'Automatic Manual(Advanced) Exit'.split()
+        choices = [u'Automatic', u'Manual(Advanced)', u'Exit']
 
         if not self._ui:
             self._ui = ButtonMenu(u'Choose Installation Type', choices)
@@ -864,7 +864,7 @@ class PartitioningMenu(ProcessStep):
 
     def build_ui_widgets(self):
         self._ui_widgets = list()
-        for key in self.choices:
+        for key in sorted(self.choices):
             button = urwid.Button(self.choices[key])
             urwid.connect_signal(button, 'click', self._item_chosen, key)
             button = urwid.AttrMap(button, None, focus_map='reversed')
@@ -1299,7 +1299,7 @@ class ConfirmUserMenu(ProcessStep):
 
     def build_ui_widgets(self):
         self._ui_widgets = list()
-        for key in self.choices:
+        for key in sorted(self.choices):
             button = urwid.Button(self.choices[key])
             urwid.connect_signal(button, 'click', self._item_chosen, key)
             button = urwid.AttrMap(button, None, focus_map='reversed')
@@ -1434,7 +1434,7 @@ class ConfirmDHCPMenu(ProcessStep):
 
     def build_ui_widgets(self):
         self._ui_widgets = list()
-        for key in self.choices:
+        for key in sorted(self.choices):
             button = urwid.Button(self.choices[key])
             urwid.connect_signal(button, 'click', self._item_chosen, key)
             button = urwid.AttrMap(button, None, focus_map='reversed')


### PR DESCRIPTION
The options are defined in ister_gui as python dictionaries, which
are inherently unordered. By calling sorted() on the options the
dictionaries are guaranteed to be sorted by key.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>