### PR TITLE
Add space after partition name in disk wipe confirmation, pep8 fixes

### DIFF
--- a/ister_gui.py
+++ b/ister_gui.py
@@ -674,7 +674,8 @@ class TelemetryDisclosure(ProcessStep):
                            'you change your mind.'
         self.progress = urwid.Text('Step {} of {}'.format(cur_step, tot_steps))
         self.message = urwid.Text(self._msg_prefix + self._msg_suffix)
-        self.accept = urwid.CheckBox('Yes.', on_state_change=self._on_opt_in_change)
+        self.accept = urwid.CheckBox('Yes.',
+                                     on_state_change=self._on_opt_in_change)
 
     def _on_opt_in_change(self, cbox, _):
         if cbox.get_state():
@@ -721,7 +722,6 @@ class TelemetryDisclosure(ProcessStep):
     def build_ui(self):
         self._ui = SimpleForm(u'Stability Enhancement Program',
                               self._ui_widgets, buttons=["Previous", "Next"])
-
 
 
 class StartInstaller(ProcessStep):
@@ -858,8 +858,8 @@ class ConfirmDiskWipe(ConfirmStep):
                 # leave space between part name and size so long partition
                 # names such as mmcblk1p1 don't bump into the partition size
                 self.text += '{0:10} {1:6}{2:28}\n'.format(part["name"],
-                                                          part["size"],
-                                                          part["type"])
+                                                           part["size"],
+                                                           part["type"])
         alert = Alert(self._title,
                       self.text,
                       labels=[u'No', u'Yes'])

--- a/ister_gui.py
+++ b/ister_gui.py
@@ -855,7 +855,9 @@ class ConfirmDiskWipe(ConfirmStep):
             self.text += "{0} contents: no partitions found.".format(disk)
         else:
             for part in disk_info["partitions"]:
-                self.text += '{0:10}{1:6}{2:28}\n'.format(part["name"],
+                # leave space between part name and size so long partition
+                # names such as mmcblk1p1 don't bump into the partition size
+                self.text += '{0:10} {1:6}{2:28}\n'.format(part["name"],
                                                           part["size"],
                                                           part["type"])
         alert = Alert(self._title,


### PR DESCRIPTION
When partition names are 9 characters or more they bump up against
the partition size in the disk wipe confirmation menu. Add a space
after the partition name so this will not happen.

Also fix a few pep8 complaints:
- 677: line too long
- 727: too many blank lines
- 861: continuation line under-indented
- 862: continuation line under-indented