### PR TITLE
Add '-- required --' text above required bundles

### DIFF
--- a/ister_gui.py
+++ b/ister_gui.py
@@ -1299,6 +1299,9 @@ class BundleSelectorStep(ProcessStep):
             desc_text = urwid.Text(bundle['desc'])
             column = urwid.Columns([check, ('weight', 2, desc_text)])
             self._ui_widgets.append(column)
+
+        self._ui_widgets.extend([urwid.Divider(),
+                                 urwid.Text('--- required ---')])
         for bundle in self.required_bundles:
             text_name = urwid.Text('[X] {0}'.format(bundle['name']))
             text_desc = urwid.Text(bundle['desc'])


### PR DESCRIPTION
Without the text divider, the bundles look like it is possible to
select and unselect them. When tabbing through, the focus actually
skips over the required bundles, causing the user to blow past the
'Next' button.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>