### PR TITLE
Add checks for BundleSelectorStep arguments

### DIFF
--- a/ister_gui.py
+++ b/ister_gui.py
@@ -1229,7 +1229,7 @@ class MountPointsStep(ProcessStep):
 
 class BundleSelectorStep(ProcessStep):
     """UI which displays the bundle list to be installed"""
-    def __init__(self, cur_step, tot_steps):
+    def __init__(self, cur_step=None, tot_steps=None):
         super(BundleSelectorStep, self).__init__()
         self.bundles = [{'name': 'editors',
                          'desc': 'Popular text editors (terminal-based)'},
@@ -1266,7 +1266,9 @@ class BundleSelectorStep(ProcessStep):
              'desc': 'Required to update the system'},
             {'name': 'os-utils',
              'desc': 'A core set of OS utilities'}])
-        self.progress = urwid.Text('Step {} of {}'.format(cur_step, tot_steps))
+        if cur_step and tot_steps:
+            self.progress = urwid.Text('Step {} of {}'.format(cur_step,
+                                                              tot_steps))
 
     def handler(self, config):
         if not self._ui_widgets:
@@ -1292,10 +1294,11 @@ class BundleSelectorStep(ProcessStep):
         return self._ui.do_form()
 
     def build_ui_widgets(self):
-        self._ui_widgets = [self.progress,
-                            urwid.Divider(),
-                            urwid.Text('Select the bundles to install:'),
-                            urwid.Divider()]
+        self._ui_widgets = []
+        if self.progress:
+            self._ui_widgets = [self.progress, urwid.Divider()]
+        self._ui_widgets.extend([urwid.Text('Select the bundles to install:'),
+                                 urwid.Divider()])
         for bundle in self.bundles:
             check = urwid.CheckBox(bundle['name'])
             desc_text = urwid.Text(bundle['desc'])


### PR DESCRIPTION
This class can be instantiated for the sole purpose of retreiving a
list of required bundles. In this case it should not be necessary to
pass cur_step and tot_steps arguments since they will not be used.

This sets default values of None and only builds the progress widget
if values have been passed to the constructor. This prevents a crash
when the installation confirmation step is reached.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>