### PR TITLE
Add network check on splash screen

### DIFF
--- a/ister.py
+++ b/ister.py
@@ -60,7 +60,7 @@ LOG = None
 DEBUG = False
 
 
-def run_command(cmd, raise_exception=True, log_output=True):
+def run_command(cmd, raise_exception=True, log_output=True, environ=None):
     """Execute given command in a subprocess
 
     This function will raise an Exception if the command fails unless
@@ -71,7 +71,8 @@ def run_command(cmd, raise_exception=True, log_output=True):
         sys.stdout.flush()
         proc = subprocess.Popen(cmd.split(" "),
                                 stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
+                                stderr=subprocess.PIPE,
+                                env=environ)
         lines = proc.stdout
         output = []
         for line in lines:
@@ -398,7 +399,14 @@ def copy_os(args, template, target_dir):
         os.makedirs("{0}/var/tmp".format(target_dir))
         run_command("mount --bind {0}/var/tmp /var/lib/swupd"
                     .format(target_dir))
-    run_command(swupd_command)
+    swupd_env = os.environ
+    if "Proxy" in template and template["Proxy"]:
+        proxy = "https_proxy={} ".format(template["Proxy"])
+        swupd_env["http_proxy"] = proxy
+        swupd_env["https_proxy"] = proxy
+        LOG.debug("proxy: {}".format(proxy))
+
+    run_command(swupd_command, environ=swupd_env)
 
 
 class ChrootOpen(object):


### PR DESCRIPTION
Display network requirements and give indication of whether
the system is able to connect to clearlinux.org or not. Allow the
user to configure a static ip address, gateway, and interface for the
installer to use.

Also add configurable proxy to installer gui and pass to swupd via the
json template. This way, if pacrunner is not working the user can
define their own proxies to connect to clearlinux.org for the
installation.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>