### PR TITLE
Set user's full name in /etc/passwd

### DIFF
--- a/ister.py
+++ b/ister.py
@@ -465,6 +465,23 @@ def create_account(user, target_dir):
         run_command(command)
 
 
+def add_user_fullname(user, target_dir):
+    """Add user's full name to /etc/passwd
+
+    If the user's full name is set in the template, use chfn to set their full
+    name in the GECOS field of the /etc/passwd file
+    """
+    try:
+        command = ["chfn", "-f", user["fullname"], user["username"]]
+
+        with ChrootOpen(target_dir) as _:
+            subprocess.call(command)
+    except Exception as exep:
+        print(exep)
+        LOG.info("Unable to set user {} full name: {}".format(user["username"],
+                                                              exep))
+
+
 def add_user_key(user, target_dir):
     """Append public key to user's ssh authorized_keys file
 
@@ -543,6 +560,8 @@ def add_users(template, target_dir):
         if user.get("sudo") and user["sudo"]:
             setup_sudo(user, target_dir)
             disable_root_login(target_dir)
+        if user.get("fullname"):
+            add_user_fullname(user, target_dir)
 
 
 def set_hostname(template, target_dir):

--- a/ister_gui.py
+++ b/ister_gui.py
@@ -1627,6 +1627,16 @@ class UserConfigurationStep(ProcessStep):
 
         self.edit_username.set_edit_text(name_text + lastname_text)
 
+    def _set_fullname(self, user):
+        fname = self.edit_name.get_edit_text()
+        lname = self.edit_lastname.get_edit_text()
+        if fname or lname:
+            if fname and lname:
+                user['fullname'] = '{} {}'.format(fname, lname)
+            else:
+                user['fullname'] = fname or lname
+
+
     def handler(self, config):
         if not self._ui_widgets:
             self.build_ui_widgets()
@@ -1656,6 +1666,8 @@ class UserConfigurationStep(ProcessStep):
         tmp['password'] = crypt.crypt(self.edit_password.get_edit_text(),
                                       'aa')
         tmp['sudo'] = self.sudo.get_state()
+        self._set_fullname(tmp)
+
         config['Users'] = [tmp]
         return self._action
 

--- a/ister_test.py
+++ b/ister_test.py
@@ -1519,6 +1519,7 @@ def add_users_good():
     backup_add_user_key = ister.add_user_key
     backup_setup_sudo = ister.setup_sudo
     backup_disable_root_login = ister.disable_root_login
+    backup_add_user_fullname = ister.add_user_fullname
 
     def mock_create_account(user, target_dir):
         """mock_create_account wrapper"""
@@ -1539,10 +1540,15 @@ def add_users_good():
         """mock_disable_root_login wrapper"""
         COMMAND_RESULTS.append("password")
 
+    def mock_add_user_fullname(_, __):
+        """mock_add_user_fullname wrapper"""
+        COMMAND_RESULTS.append("fullname")
+
     ister.create_account = mock_create_account
     ister.add_user_key = mock_add_user_key
     ister.setup_sudo = mock_setup_sudo
     ister.disable_root_login = mock_disable_root_login
+    ister.add_user_fullname = mock_add_user_fullname
     global COMMAND_RESULTS
     COMMAND_RESULTS = []
     target_dir = "/tmp"
@@ -1559,16 +1565,18 @@ def add_users_good():
                 "sudo",
                 "password",
                 "four",
-                target_dir]
+                target_dir,
+                "fullname"]
     template = {"Users": [{"n": "one", "key": "akey", "sudo": True},
                           {"n": "two", "key": "akey", "sudo": False},
                           {"n": "three", "sudo": True},
-                          {"n": "four"}]}
+                          {"n": "four", "fullname": "Test User"}]}
     ister.add_users(template, target_dir)
     ister.create_account = backup_create_account
     ister.add_user_key = backup_add_user_key
     ister.setup_sudo = backup_setup_sudo
     ister.disable_root_login = backup_disable_root_login
+    ister.add_user_fullname = backup_add_user_fullname
     commands_compare_helper(commands)
 
 
@@ -1587,6 +1595,27 @@ def add_users_none():
         raise exep
     finally:
         ister.create_account = backup_create_account
+
+
+@chroot_open_wrapper("silent")
+def add_user_fullname():
+    import subprocess
+
+    global COMMAND_RESULTS
+    COMMAND_RESULTS = []
+
+    def mock_call(cmd):
+        """mock_call wrapper"""
+        COMMAND_RESULTS.extend(cmd)
+
+    backup_call = subprocess.call
+    subprocess.call = mock_call
+
+    template = {"fullname": "Test User", "username": "user"}
+    commands = ["chfn", "-f", "Test User", "user"]
+    ister.add_user_fullname(template, "/tmp")
+    subprocess.call = backup_call
+    commands_compare_helper(commands)
 
 
 @run_command_wrapper
@@ -4021,6 +4050,95 @@ def gui_set_proxy():
             raise Exception("Proxy not set properly in config")
 
 
+def gui_set_fullname_fname_lname_present():
+    """
+    Set the user's full name in the gui with first and last names present
+    """
+
+    class Edit():
+        """mock uwrid.Edit class"""
+        def __init__(self, edit_text):
+            self.edit_text = edit_text
+
+        def get_edit_text(self):
+            return self.edit_text
+
+    userconfig = ister_gui.UserConfigurationStep(0, 0)
+    temp = {}
+    userconfig.edit_name = Edit("Test")
+    userconfig.edit_lastname = Edit("User")
+    userconfig._set_fullname(temp)
+    if "fullname" not in temp or temp["fullname"] != "Test User":
+        raise Exception("Gui failed to set user fullname properly")
+
+
+def gui_set_fullname_fname_present():
+    """
+    Set the user's full name in the gui with only first name present
+    """
+
+    class Edit():
+        """mock uwrid.Edit class"""
+        def __init__(self, edit_text):
+            self.edit_text = edit_text
+
+        def get_edit_text(self):
+            return self.edit_text
+
+    userconfig = ister_gui.UserConfigurationStep(0, 0)
+    temp = {}
+    userconfig.edit_name = Edit("Test")
+    userconfig.edit_lastname = Edit("")
+    userconfig._set_fullname(temp)
+    if "fullname" not in temp or temp["fullname"] != "Test":
+        raise Exception("Gui failed to set user fullname properly")
+
+
+def gui_set_fullname_lname_present():
+    """
+    Set the user's full name in the gui with only last name present
+    """
+
+    class Edit():
+        """mock uwrid.Edit class"""
+        def __init__(self, edit_text):
+            self.edit_text = edit_text
+
+        def get_edit_text(self):
+            return self.edit_text
+
+    userconfig = ister_gui.UserConfigurationStep(0, 0)
+    temp = {}
+    userconfig.edit_name = Edit("")
+    userconfig.edit_lastname = Edit("User")
+    userconfig._set_fullname(temp)
+    if "fullname" not in temp or temp["fullname"] != "User":
+        raise Exception("Gui failed to set user fullname properly")
+
+
+def gui_set_fullname_none_present():
+    """
+    The user's full name should not be set in the gui if none are configured
+    by the user
+    """
+
+    class Edit():
+        """mock uwrid.Edit class"""
+        def __init__(self, edit_text):
+            self.edit_text = edit_text
+
+        def get_edit_text(self):
+            return self.edit_text
+
+    userconfig = ister_gui.UserConfigurationStep(0, 0)
+    temp = {}
+    userconfig.edit_name = Edit("")
+    userconfig.edit_lastname = Edit("")
+    userconfig._set_fullname(temp)
+    if "fullname" in temp:
+        raise Exception("Gui set user fullname when no fullname was present")
+
+
 def run_tests(tests):
     """Run ister test suite"""
     fail = 0
@@ -4108,6 +4226,7 @@ if __name__ == '__main__':
         setup_sudo_bad,
         add_users_good,
         add_users_none,
+        add_user_fullname,
         post_install_nonchroot_good,
         cleanup_physical_good,
         cleanup_virtual_good,
@@ -4228,7 +4347,11 @@ if __name__ == '__main__':
         gui_network_connection_with_proxy,
         gui_network_connection_no_proxy_when_required,
         gui_static_configuration,
-        gui_set_proxy
+        gui_set_proxy,
+        gui_set_fullname_fname_lname_present,
+        gui_set_fullname_fname_present,
+        gui_set_fullname_lname_present,
+        gui_set_fullname_none_present
     ]
 
     failed = run_tests(TESTS)


### PR DESCRIPTION
The gui provides capability for the user to set their first and
last name during setup, but the installer did not set the name
in /etc/passwd. This uses the chfn tool to set the user's full
name.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>