### PR TITLE
Update the bundle select screen

### DIFF
--- a/ister_gui.py
+++ b/ister_gui.py
@@ -1209,8 +1209,8 @@ class TelemetryDisclosure(ProcessStep):
                            '\n\n' \
                            'See http://clearlinux.org/features/telemetry ' \
                            'for more information.\n\n'
-        self._msg_suffix = 'Install the telemetrics-client bundle later if '\
-                           'you change your mind.'
+        self._msg_suffix = 'Install the telemetrics bundle later if you '\
+                           'change your mind.'
         self.progress = urwid.Text('Step {} of {}'.format(cur_step, tot_steps))
         self.message = urwid.Text(self._msg_prefix + self._msg_suffix)
         self.accept = urwid.CheckBox('Yes.',
@@ -1785,10 +1785,20 @@ class BundleSelectorStep(ProcessStep):
                                                               tot_steps))
 
     def handler(self, config):
-        if not self._ui_widgets:
-            self.build_ui_widgets()
-        if not self._ui:
-            self.build_ui()
+        if 'telemetrics' in config['Bundles']:
+            self.required_bundles.append(
+                    {'name': 'telemetrics',
+                     'desc': 'Collects anonymous reports to improve '
+                             'system stability (opted in)'})
+        else:
+            self.required_bundles = [
+                    bundle for bundle in self.required_bundles
+                    if not (bundle.get('name') == 'telemetrics')]
+
+        # build widgets and ui each time in case user went back and opted out
+        # of telemetrics
+        self.build_ui_widgets()
+        self.build_ui()
         self._action = self.run_ui()
         for widget in self._ui_widgets[2:]:
             if isinstance(widget, urwid.Columns):

--- a/ister_gui.py
+++ b/ister_gui.py
@@ -1832,7 +1832,7 @@ class BundleSelectorStep(ProcessStep):
         self._ui_widgets.extend([urwid.Divider(),
                                  urwid.Text('--- required ---')])
         for bundle in self.required_bundles:
-            text_name = urwid.Text('[X] {0}'.format(bundle['name']))
+            text_name = urwid.Text(' X  {0}'.format(bundle['name']))
             text_desc = urwid.Text(bundle['desc'])
             column = urwid.Columns([text_name, ('weight', 2, text_desc)])
             self._ui_widgets.append(column)


### PR DESCRIPTION
- Update bundle select screen to show telemetrics

  If the user opted in, this screen shows the telemetrics bundle as part
  of the required bundle list. If the user did not opt in it does not
  appear. The user can also change their mind and this list is updated.

- Remove brackets from required bundle selections

  The square brackets surrounding the 'X' in front of the required
  bundles confused some users in the UX review. The required bundles
  looked like they were selectable because they were the same format
  as the optional bundles. Removing the brackets makes the required
  bundles look unselectable.
