### PR TITLE
Increase pycurl timeout from 1 second to 3 seconds

### DIFF
--- a/ister_gui.py
+++ b/ister_gui.py
@@ -1138,7 +1138,7 @@ class NetworkRequirements(ProcessStep):
         curl.setopt(curl.HEADER, 1)
         curl.setopt(curl.NOBODY, 1)
         curl.setopt(curl.HEADERFUNCTION, headers.store)
-        curl.setopt(curl.TIMEOUT, 1)
+        curl.setopt(curl.TIMEOUT, 3)
 
         try:
             curl.perform()


### PR DESCRIPTION
**Proposed** - on my home network, one second was not long enough

On slower networks one second is too short a time to receive a response
from clearlinux.org, causing a 'none detected' warning when there is
in fact a network connection. A three second timeout decreases the risk
of this false negative.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>