### PR TITLE
Allow user to continue with undetected interface settings

### DIFF
--- a/ister_gui.py
+++ b/ister_gui.py
@@ -1026,10 +1026,13 @@ class NetworkRequirements(ProcessStep):
         try:
             ipaddress.ip_address(self.static_ip.get_edit_text())
         except Exception as err:
-            self.error = 'The configuration for "ip" is invalid {}'.format(err)
-            # an empty action signals to refresh the page
-            self._action = ''
-        if self.interface.get_edit_text() not in self.ifaceaddrs.keys():
+            if self._action not in ['Next', 'Previous']:
+                self.error = 'The configuration for "ip" is invalid {}'\
+                             .format(err)
+                # an empty action signals to refresh the page
+                self._action = ''
+        if self.interface.get_edit_text() not in self.ifaceaddrs.keys() \
+                and self._action not in ['Next', 'Previous']:
             self.error = 'Interface "{}" not detected'\
                          .format(self.interface.get_edit_text())
             # an empty action signals to refresh the page


### PR DESCRIPTION
This patch allows the user to continue to the next screen if they
modified the interface/ip/gateway information unintentially and
did not attempt to set it.

The interface settings should not restrict the user from advancing
to the next screen in the installer. Even if there is no network
connection, they could still choose an action other than install
on the ChooseAction screen.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>