### PR TITLE
Redesign network screen

### DIFF
--- a/ister_gui.py
+++ b/ister_gui.py
@@ -1010,6 +1010,7 @@ class NetworkRequirements(ProcessStep):
         self.static_ip = None
         self.interface = None
         self.gateway = None
+        self.dns = None
         self.error = None
         self.config = None
         self.ifaceaddrs = None
@@ -1102,6 +1103,7 @@ class NetworkRequirements(ProcessStep):
             gateway = 'none found'
 
         self.gateway = urwid.Edit(fmt.format('Gateway: '), gateway)
+        self.dns = urwid.Edit(fmt.format('DNS (optional): '))
         self._ui_widgets = [self.progress,
                             urwid.Divider(),
                             wired_req,
@@ -1118,6 +1120,7 @@ class NetworkRequirements(ProcessStep):
                             self.interface,
                             self.static_ip,
                             self.gateway,
+                            self.dns,
                             urwid.Divider(),
                             self.static_col,
                             urwid.Divider()]
@@ -1214,12 +1217,14 @@ class NetworkRequirements(ProcessStep):
         if not os.path.exists(path):
             os.makedirs(path)
 
-        with open(path + "10-en-static.network", "w") as nfile:
-            nfile.write("[Match]\n")
-            nfile.write("Name={}\n\n".format(self.interface.get_edit_text()))
-            nfile.write("[Network]\n")
-            nfile.write("Address={0}\n".format(self.static_ip.get_edit_text()))
-            nfile.write("Gateway={0}\n".format(self.gateway.get_edit_text()))
+        with open(path + '10-en-static.network', 'w') as nfile:
+            nfile.write('[Match]\n')
+            nfile.write('Name={}\n\n'.format(self.interface.get_edit_text()))
+            nfile.write('[Network]\n')
+            nfile.write('Address={}\n'.format(self.static_ip.get_edit_text()))
+            nfile.write('Gateway={}\n'.format(self.gateway.get_edit_text()))
+            if self.dns.get_edit_text():
+                nfile.write('DNS={}\n'.format(self.dns.get_edit_text()))
 
         try:
             subprocess.call(['/usr/bin/systemctl', 'restart',

--- a/ister_test.py
+++ b/ister_test.py
@@ -4036,12 +4036,20 @@ def gui_static_configuration():
     os.makedirs = mock_makedirs
     time.sleep = mock_sleep
 
+    # we will be running the function twice, once without then once with DNS
     commands = ['/etc/systemd/network/10-en-static.network', 'w',
                 '[Match]\n',
                 'Name=enp0s1\n\n',
                 '[Network]\n',
                 'Address=10.0.2.15\n',
-                'Gateway=10.0.2.2\n']
+                'Gateway=10.0.2.2\n',
+                '/etc/systemd/network/10-en-static.network', 'w',
+                '[Match]\n',
+                'Name=enp0s1\n\n',
+                '[Network]\n',
+                'Address=10.0.2.15\n',
+                'Gateway=10.0.2.2\n',
+                'DNS=10.0.2.3\n']
 
     netreq = ister_gui.NetworkRequirements(0, 0)
     netreq.config = {}
@@ -4051,15 +4059,23 @@ def gui_static_configuration():
     netreq.gateway = Edit("10.0.2.2")
     try:
         netreq._static_configuration(None)
-    except Exception:
+    except:
         # this method always exits with an exception (urwid.ExitMainLoop)
         pass
+
+    # set dns and run _static_configuration again
+    netreq.dns = Edit("10.0.2.3")
+    try:
+        netreq._static_configuration(None)
+    except:
+        # this method always exits with an exception (urwid.ExitMainLoop)
+        pass
+
+    commands_compare_helper(commands)
 
     subprocess.call = call_backup
     os.makedirs = makedirs_backup
     time.sleep = sleep_backup
-
-    commands_compare_helper(commands)
 
 
 def gui_set_proxy():


### PR DESCRIPTION
* Redesign network screen to group like config options 

  This was a confusing screen because it was not clear which buttons
  were related to which configuration field. They are not grouped in
  a logical manner and the < reset network > button only appears when
  it is relevant.

  Also remove the .8 second sleep on startup since this is no longer
  the first screen. The time the user spends on the splash screen will
  allow the network units to start up.

* Add optional DNS setting to static IP configuration