### PR TITLE
Change ister GUI to a dark theme

### DIFF
--- a/ister_gui.py
+++ b/ister_gui.py
@@ -64,18 +64,18 @@ import ister
 
 PALETTE = [
     ('header', 'white', 'dark red', 'bold'),
-    ('banner', 'black', 'light gray'),
-    ('bg', 'black', 'dark blue'),
+    ('banner', 'white', 'dark gray'),
+    ('bg', 'black', 'black'),
     ('p1', 'white', 'dark red'),
     ('p2', 'white', 'dark green'),
     ('p3', 'white', 'dark cyan'),
     ('p4', 'white', 'dark magenta'),
     ('reversed', 'white', ''),
-    ('I say', 'black,bold', 'light gray', 'bold'),
-    ('success', 'dark green', 'light gray'),
-    ('warn', 'dark red', 'light gray'),
-    ('button', 'dark blue', 'light gray'),
-    ('ex', 'dark gray', 'light gray')]
+    ('I say', 'black,bold', 'dark gray', 'bold'),
+    ('success', 'dark green', 'dark gray'),
+    ('warn', 'dark red', 'dark gray'),
+    ('button', 'dark blue', 'dark gray'),
+    ('ex', 'dark gray', 'dark gray')]
 
 MIN_WIDTH = 80
 MIN_HEIGHT = 24


### PR DESCRIPTION
This is a proposal to change ister_gui to a dark theme. Personally I like this better than light gray on dark blue. Please see screenshots below.

![splash](https://cloud.githubusercontent.com/assets/12090084/19319737/1e192676-9063-11e6-856d-3cf68c75f036.png)
![telemetrics](https://cloud.githubusercontent.com/assets/12090084/19319741/1f90b2e4-9063-11e6-9d6d-105c6c099007.png)
![netreq_nonefound](https://cloud.githubusercontent.com/assets/12090084/19319749/27d20a48-9063-11e6-9a90-659ef26a674f.png)
![netreq_established](https://cloud.githubusercontent.com/assets/12090084/19319751/2a8f8f3a-9063-11e6-8807-115e0a9bfeed.png)
![partalert](https://cloud.githubusercontent.com/assets/12090084/19319753/2bef5bda-9063-11e6-86fe-39046730d03d.png)
![createuser](https://cloud.githubusercontent.com/assets/12090084/19319765/35b50ce6-9063-11e6-9f43-5378198187fe.png)
![bundle_selector](https://cloud.githubusercontent.com/assets/12090084/19319768/37d4b742-9063-11e6-9bbf-d4e672a4546d.png)
(can you spot the bug ^^^?)
![begininstall](https://cloud.githubusercontent.com/assets/12090084/19319769/39ac1b14-9063-11e6-8241-50eb6cbb8d70.png)
![installing](https://cloud.githubusercontent.com/assets/12090084/19319771/3ad85732-9063-11e6-9e6f-a8c6826d256c.png)
