### PR TITLE
Disable static configuration button until requirements met

### DIFF
--- a/ister_test.py
+++ b/ister_test.py
@@ -4057,6 +4057,7 @@ def gui_static_configuration():
     netreq.static_ip_e = Edit("10.0.2.15")
     netreq.interface_e = Edit("enp0s1")
     netreq.gateway_e = Edit("10.0.2.2")
+    netreq.static_ready = True
     try:
         netreq._static_configuration(None)
     except:


### PR DESCRIPTION
The static configuration button on the network requirements screen is
disabled and grayed out for the user until text is added to the three
required static configuration edit boxes.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>