### PR TITLE
Remove http_proxy settings since https_proxy is required

### DIFF
--- a/ister.py
+++ b/ister.py
@@ -409,10 +409,6 @@ def copy_os(args, template, target_dir):
         swupd_env["https_proxy"] = template["HTTPSProxy"]
         LOG.debug("https_proxy: {}".format(template["HTTPSProxy"]))
 
-    if template.get("HTTPProxy"):
-        swupd_env["http_proxy"] = template["HTTPProxy"]
-        LOG.debug("http_proxy: {}".format(template["HTTPProxy"]))
-
     run_command(swupd_command, environ=swupd_env, show_output=True)
 
 

--- a/ister_gui.py
+++ b/ister_gui.py
@@ -850,10 +850,9 @@ class ChooseAction(ProcessStep):
                                 'using the "Shell" option if the repair '
                                 'fails').do_alert()
 
-        # save proxies if they exist in case the user did not set one in the
+        # save proxy if it exist in case the user did not set one in the
         # network configuration screen
         old_https_proxy = os.environ.get('https_proxy')
-        old_http_proxy = os.environ.get('http_proxy')
 
         try:
             old_root = os.open('/', os.O_RDONLY)
@@ -867,8 +866,6 @@ class ChooseAction(ProcessStep):
         # In host OS chroot
         if old_https_proxy:
             os.environ['https_proxy'] = old_https_proxy
-        elif old_http_proxy:
-            os.environ['http_proxy'] = old_http_proxy
 
         watch = WatchableProcess(['swupd', 'verify', '--fix'])
         watch.start()
@@ -1018,7 +1015,6 @@ class NetworkRequirements(ProcessStep):
         self.interface_msg = 'Interface: '
         self.ip_msg = 'IP address: '
         self.https_proxy = None
-        self.http_proxy = None
         self.interface = None
         self.error = None
         self.config = None
@@ -1096,18 +1092,12 @@ class NetworkRequirements(ProcessStep):
         else:
             https_text = ''
 
-        if os.environ.get('http_proxy'):
-            http_text = os.environ['http_proxy']
-        else:
-            http_text = ''
-
         fmt = '{0:>20}'
         self.https_proxy = urwid.Edit(fmt.format('HTTPS proxy: '), https_text)
         self.https_col = urwid.Columns(
                 [self.https_proxy,
-                 urwid.Text(('ex', 'example: https://proxy.url.com:123'),
+                 urwid.Text(('ex', 'example: http://proxy.url.com:123'),
                             align='center')])
-        self.http_proxy = urwid.Edit(fmt.format('HTTP proxy: '), http_text)
         wired = '* Connection to clearlinux.org: '
         if self._network_connection():
             wired_req = urwid.Text(['* Connection to clearlinux.org: ',
@@ -1147,7 +1137,6 @@ class NetworkRequirements(ProcessStep):
                             self.proxy_header,
                             urwid.Divider(),
                             self.https_col,
-                            self.http_proxy,
                             urwid.Divider(),
                             self.proxy_button,
                             urwid.Divider(),
@@ -1303,10 +1292,6 @@ class NetworkRequirements(ProcessStep):
         if self.https_proxy.get_edit_text():
             self.config['HTTPSProxy'] = self.https_proxy.get_edit_text()
             os.environ['https_proxy'] = self.https_proxy.get_edit_text()
-
-        if self.http_proxy.get_edit_text():
-            self.config['HTTPProxy'] = self.http_proxy.get_edit_text()
-            os.environ['http_proxy'] = self.http_proxy.get_edit_text()
 
         raise urwid.ExitMainLoop()
 

--- a/ister_test.py
+++ b/ister_test.py
@@ -76,8 +76,7 @@ def good_virtual_disk_template():
     [{"disk" : "gvdt", "partition" : 1, "mount" : "/boot"}, {"disk" : "gvdt", \
     "partition" : 3, "mount" : "/"}], \
     "Version" : 800, "Bundles" : ["linux-kvm"], \
-    "HTTPSProxy" : "https://proxy.clear.com", \
-    "HTTPProxy" : "http://proxy.clear.com"}'
+    "HTTPSProxy" : "https://proxy.clear.com"}'
 
 
 def good_latest_template():
@@ -95,8 +94,7 @@ def good_latest_template():
     [{"disk" : "gvdt", "partition" : 1, "mount" : "/boot"}, {"disk" : "gvdt", \
     "partition" : 3, "mount" : "/"}], \
     "Version" : "latest", "Bundles" : ["linux-kvm"], \
-    "HTTPSProxy" : "https://proxy.clear.com", \
-    "HTTPProxy" : "http://proxy.clear.com"}'
+    "HTTPSProxy" : "https://proxy.clear.com"}'
 
 
 def full_user_install_template():
@@ -131,8 +129,7 @@ def run_command_wrapper(func):
                 COMMAND_RESULTS.append(False)
             if environ:
                 https_proxy = environ.get("https_proxy")
-                http_proxy = environ.get("http_proxy")
-                COMMAND_RESULTS.extend([https_proxy, http_proxy])
+                COMMAND_RESULTS.append(https_proxy)
             if show_output:
                 COMMAND_RESULTS.append(True)
         global COMMAND_RESULTS
@@ -498,7 +495,7 @@ def run_command_bad():
 @run_command_wrapper
 def run_command_with_env():
     """run_command with environment variable passed"""
-    command = ["true", os.getenv("https_proxy"), os.getenv("http_proxy")]
+    command = ["true", os.getenv("https_proxy")]
     ister.run_command("true", environ=os.environ)
     commands_compare_helper(command)
 
@@ -1233,7 +1230,6 @@ def copy_os_good():
 --contenturl=ctest --versionurl=vtest --format=formattest --statedir=/statetest"
     commands = [swupd_cmd,
                 os.getenv("https_proxy"),
-                os.getenv("http_proxy"),
                 True]
     ister.copy_os(args, {"Version": 0, "DestinationType": ""}, "/")
     ister.add_bundles = backup_add_bundles
@@ -1260,13 +1256,11 @@ def copy_os_proxy_good():
 --contenturl=ctest --versionurl=vtest --format=formattest --statedir=/statetest"
     commands = [swupd_cmd,
                 "https://to.clearlinux.org",
-                "http://to.clearlinux.org",
                 True]
     template = {
         "Version": 0,
         "DestinationType": "",
-        "HTTPSProxy": "https://to.clearlinux.org",
-        "HTTPProxy": "http://to.clearlinux.org"
+        "HTTPSProxy": "https://to.clearlinux.org"
     }
     ister.copy_os(args, template, "/")
     ister.add_bundles = backup_add_bundles
@@ -1296,7 +1290,6 @@ def copy_os_format_good():
 --contenturl=ctest --versionurl=vtest --format=test --statedir=/statetest"
     commands = [swupd_cmd,
                 os.getenv("https_proxy"),
-                os.getenv("http_proxy"),
                 True]
     ister.copy_os(args, {"Version": 0, "DestinationType": ""}, "/")
     ister.add_bundles = backup_add_bundles
@@ -1326,7 +1319,6 @@ def copy_os_which_good():
     swupd_cmd = "stdbuf -o 0 {0}".format(swupd_cmd)
     commands = [swupd_cmd,
                 os.getenv("https_proxy"),
-                os.getenv("http_proxy"),
                 True]
     ister.copy_os(args, {"Version": 0, "DestinationType": ""}, "/")
     ister.add_bundles = backup_add_bundles
@@ -1362,7 +1354,6 @@ def copy_os_physical_good():
                 "mount --bind //var/tmp /var/lib/swupd",
                 swupd_cmd,
                 os.getenv("https_proxy"),
-                os.getenv("http_proxy"),
                 True]
     ister.copy_os(args, {"Version": 0, "DestinationType": "physical"}, "/")
     ister.add_bundles = backup_add_bundles
@@ -4102,8 +4093,7 @@ def gui_set_proxy():
 
     netreq = ister_gui.NetworkRequirements(1, 1)
     netreq.config = {}
-    netreq.https_proxy = Edit("https://to.clearlinux.org:1080")
-    netreq.http_proxy = Edit("http://to.clearlinux.org:1080")
+    netreq.https_proxy = Edit("http://to.clearlinux.org:1080")
     try:
         netreq._set_proxy(None)
     except Exception:
@@ -4112,11 +4102,7 @@ def gui_set_proxy():
 
     time.sleep = sleep_backup
     if "HTTPSProxy" in netreq.config:
-        if netreq.config["HTTPSProxy"] != "https://to.clearlinux.org:1080":
-            raise Exception("Proxy not set properly in config")
-
-    if "HTTPProxy" in netreq.config:
-        if netreq.config["HTTPProxy"] != "http://to.clearlinux.org:1080":
+        if netreq.config["HTTPSProxy"] != "http://to.clearlinux.org:1080":
             raise Exception("Proxy not set properly in config")
 
 


### PR DESCRIPTION
cURL requires a https_proxy (with http url scheme) to talk to
clearlinux.org. This removes all the http_proxy settings and
updates the example text to show a http url scheme.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>