### PR TITLE
Add scripts helpful for testing and development

### DIFF
--- a/copy_files.sh
+++ b/copy_files.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/bash
+# usage: update_gui_expect.sh <disk image> <file> <target dir>
+
+function usage()
+{
+    echo "Usage: $0 <disk.img>"
+    exit 1
+}
+
+if [ $1 == "-h" ]
+then
+        usage
+fi
+
+if [ ! -e $1 ]
+then
+        echo $1: Does not exist
+        exit 1
+fi
+
+mnt=$(/usr/bin/mktemp -d)
+next_dev=$(sudo losetup -f --show -P $1)
+sudo /usr/bin/mount ${next_dev}p2 $mnt
+sudo cp $2 ${mnt}$3
+sudo /usr/bin/umount $mnt
+sudo /usr/bin/losetup -D
+echo "$1 up to date with latest gui and installer"

--- a/update_installer.sh
+++ b/update_installer.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/bash
+# usage: update_installer.sh <disk image>
+
+function usage()
+{
+    echo "Usage: $0 <disk.img>"
+    exit 1
+}
+
+if [ $# -ne 1 ]
+then
+        usage
+fi
+
+if [ $1 == "-h" ]
+then
+        usage
+fi
+
+if [ ! -e $1 ]
+then
+        echo $1: Does not exist
+        exit 1
+fi
+
+mnt=$(/usr/bin/mktemp -d)
+next_dev=$(sudo losetup -f --show -P $1)
+sudo /usr/bin/mount ${next_dev}p2 $mnt
+sudo cp ister_gui.py ${mnt}/usr/bin/ister_gui.py
+sudo cp ister.py ${mnt}/usr/bin/ister.py
+sudo /usr/bin/umount $mnt
+sudo /usr/bin/losetup -D
+echo "$1 up to date with latest gui and installer"


### PR DESCRIPTION
These scripts help when testing changes made to the installer.

- copy_files.sh
  Copies arbitrary files into image at user-provided file path.
- update_installer.sh
  Copies ister.py and ister_gui.py into correct locations in
  user-provided images.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>