### PR TITLE
Ignore SIGINT as it only freezes the TTY

### DIFF
--- a/ister_gui.py
+++ b/ister_gui.py
@@ -56,6 +56,7 @@ import shutil
 import ipaddress
 import netifaces
 import pycurl
+import signal
 
 # pylint: disable=E0401
 import urwid
@@ -2697,6 +2698,8 @@ def main():
     """Entry point for the ui"""
     setup()
     args = handle_options()
+    # Don't die on CTRL-C, as it only freezes the TTY
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
     ins = Installation(**vars(args))
     ins.run()
 


### PR DESCRIPTION
Sending CTRL-C to the installer does not do anything but show a
meaningless python stacktrace and freeze the installer. This signal
should be ignored altogether.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>