### PR TITLE
Remove duplicate mount point partition information

### DIFF
--- a/ister_gui.py
+++ b/ister_gui.py
@@ -1863,6 +1863,9 @@ class SetMountEachStep(ProcessStep):
             Alert('Information', "Format required for '/' partition, setting "
                   "format option...").do_alert()
         if self._action == 'Next' and len(point) > 0 and point[0] == '/':
+            for key in list(config.keys()):
+                if config[key]['part'] == self._partition:
+                    del config[key]
             config[point] = {'part': self._partition, 'format': _format}
             return point
         return self._action


### PR DESCRIPTION
This fixes a bug where a configuration is saved in which a mount point
is associated with a certain partition, then the user changes the mount
point associated with that partition. Since the configuration keys off
the mount point, not the partition number, there would exist two mount
points for the same partition, causing a fatal error.

This bug could be reproduced by:

1. User sets mount point (e.g. /home) on a partition (e.g. partition 2)
   and hits "Next" causing Ister to save the configuration.
2. User hits "Previous" and re-navigates to the manual mount point
   screen.
3. User changes the mount point on partition 2 to a different name (e.g.
   /boot) and hits "Next".

The above steps caused an error alert and failure exit from Ister.

This patch removes old duplicate entries if they exist at the time the
user updates the partition mount point.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>