### PR TITLE
Add 'Exit' button to path option screen

### DIFF
--- a/ister_gui.py
+++ b/ister_gui.py
@@ -778,6 +778,12 @@ class ChooseAction(ProcessStep):
                                   user_data=key)
             self._ui_widgets.append(button)
 
+        # Add the exit button last so it is at the bottom of the choices list
+        exit_button = ister_button('Exit    - Exit installer',
+                                   on_press=self._item_chosen,
+                                   user_data='Exit')
+        self._ui_widgets.append(exit_button)
+
     def _item_chosen(self, _, choice):
         self._clicked = choice
         raise urwid.ExitMainLoop()


### PR DESCRIPTION
An 'Exit' option was not offered until the screen to choose automatic or
manual install. This made sense when installation was the only user
option, but Ister now provides Repair and Shell options as well. The
Exit option should be presented at this point.

Resolves CLEAR-1844

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>