### PR TITLE
Add keyboard selection screen to installer gui

### DIFF
--- a/autoinstall.expect
+++ b/autoinstall.expect
@@ -48,6 +48,7 @@ spawn /usr/bin/python3 /usr/bin/ister_gui.py --exit-after
 match_max 100000
 expect -re ".*Clear Linux OS for Intel Architecture Installer.*"
 send -- "\r"
+send -- "\t"
 expect -re ".*Network Requirements.*"
 send -- "\t"
 send -- "\t"

--- a/maninstall.expect
+++ b/maninstall.expect
@@ -48,6 +48,7 @@ spawn /usr/bin/python3 /usr/bin/ister_gui.py --exit-after
 match_max 100000
 expect -re ".*Clear Linux OS for Intel Architecture Installer.*"
 send -- "\r"
+send -- "\t"
 expect -re ".*Network Requirements.*"
 send -- "\t"
 send -- "\t"


### PR DESCRIPTION
Adds a keyboard selection menu to ister_gui, which allows the user to
select the layout of their keyboard. The keyboard mapping defaults to
us.

Requires the addition of `kbd` to the os-installer bundle.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>