### PR TITLE
Allow configuration to dictate network testing

### DIFF
--- a/ister.py
+++ b/ister.py
@@ -1290,10 +1290,10 @@ def handle_options():
                         default=None,
                         help="Path to template file to use")
     parser.add_argument("-V", "--versionurl", action="store",
-                        default="https://download.clearlinux.org/update",
+                        default="https://cdn.download.clearlinux.org/update",
                         help="URL to use for looking for update versions")
     parser.add_argument("-C", "--contenturl", action="store",
-                        default="https://download.clearlinux.org/update",
+                        default="https://cdn.download.clearlinux.org/update",
                         help="URL to use for looking for update content")
     parser.add_argument("-f", "--format", action="store", default=None,
                         help="format to use for looking for update content")


### PR DESCRIPTION
Instead of always testing the clearlinux website as the network
available standard, make use of the content and version urls passed in
as arguments. At the same time update the clearlinux urls to reflect the
cdn to the update content instead of the main page similar to how the
swupd-client itself works.