### PR TITLE
Remove/replace deprecated bundles

### DIFF
--- a/ister_gui.py
+++ b/ister_gui.py
@@ -2261,7 +2261,9 @@ class BundleSelectorStep(ProcessStep):
                         {'name': 'user-basic',
                          'desc': 'Captures most console work flows'},
                         {'name': 'desktop-autostart',
-                         'desc': 'UI that automatically starts on boot'}]
+                         'desc': 'UI that automatically starts on boot'},
+                        {'name': 'dev-utils',
+                         'desc': 'Utilities to assist application development'}]
         self.default_bundles = [{'name': 'network-basic',
                                  'desc': 'Run network utilities and modify '
                                          'network settings'},

--- a/ister_gui.py
+++ b/ister_gui.py
@@ -2260,16 +2260,8 @@ class BundleSelectorStep(ProcessStep):
                          'desc': 'Popular text editors (terminal-based)'},
                         {'name': 'user-basic',
                          'desc': 'Captures most console work flows'},
-                        {'name': 'devtools-basic',
-                         'desc': 'gcc and minimal R, go, hpc, perl, python, '
-                                 'ruby'},
-                        {'name': 'sysadmin',
-                         'desc': 'Tools sys-admins commonly use'},
-                        {'name': 'net-utils',
-                         'desc': 'Core network config and debug'},
-                        {'name': 'network-proxy-client',
-                         'desc': 'Auto proxy detection for aware tools like '
-                                 'swupd'}]
+                        {'name': 'desktop-autostart',
+                         'desc': 'UI that automatically starts on boot'}]
         self.default_bundles = [{'name': 'network-basic',
                                  'desc': 'Run network utilities and modify '
                                          'network settings'},


### PR DESCRIPTION
The following bundles have been deprecated, and are removed from the
bundles list in ister_gui:

sysadmin
net-utils
network-proxy-client
devtools-basic

The following bundle has been added as optional:

desktop-autostart

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>