### PR TITLE
Allow generic static configuration for installer

### DIFF
--- a/ister_gui.py
+++ b/ister_gui.py
@@ -1462,6 +1462,7 @@ class NetworkRequirements(ProcessStep):
         self.config = config
         self.netcontrol = NetworkControl(target=self._static_configuration,
                                          allow_reset=True,
+                                         gen_en=True,
                                          header='Static IP Configuration '
                                                 '(optional)')
 
@@ -1606,12 +1607,6 @@ class NetworkRequirements(ProcessStep):
             ipaddress.ip_address(self.netcontrol.static_ip_e.get_edit_text())
             ipaddress.ip_address(self.netcontrol.gateway_e.get_edit_text())
         except ValueError:
-            # the main loop is waiting on this method to exit so it can report
-            # the error
-            raise urwid.ExitMainLoop()
-
-        ifaces = self.netcontrol.ifaceaddrs.keys()
-        if self.netcontrol.interface_e.get_edit_text() not in ifaces:
             # the main loop is waiting on this method to exit so it can report
             # the error
             raise urwid.ExitMainLoop()


### PR DESCRIPTION
Allow user to set an interface pattern instead of requiring the exact
and existing NIC in the static interface field. This allows users to set
a static network configuration when no interfaces have been configured.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>

**WIP**

I'll be looking into displaying the names of all available NICs. This was opened at this point since this is a quick fix to an issue users are seeing, and we may want to merge as-is. Adding part two of this may be a rather involved process.