### PR TITLE
Use dd not qemu img

### DIFF
--- a/ister.py
+++ b/ister.py
@@ -84,20 +84,29 @@ def run_command(cmd, raise_exception=True, log_output=True, environ=None,
                                 env=environ,
                                 shell=shell)
         lines = proc.stdout
-        output = []
+        stdout = []
         for line in lines:
             decoded_line = line.decode('ascii', 'ignore').rstrip()
-            output.append(decoded_line)
+            stdout.append(decoded_line)
             if show_output:
                 LOG.info(decoded_line)
             elif log_output:
                 LOG.debug(decoded_line)
+        lines = proc.stderr
+        stderr = []
+        for line in lines:
+            decoded_line = line.decode('ascii', 'ignore').rstrip()
+            stderr.append(decoded_line)
+            if show_output:
+                LOG.info(decoded_line)
+            elif log_output:
+                LOG.debug(decoded_line)
+
         if proc.poll() and raise_exception:
-            decoded_line = proc.stderr.read().decode().rstrip()
-            output.append(decoded_line)
-            LOG.debug("Error {0}".format(decoded_line))
-            raise Exception("{0} failed".format(cmd))
-        return output, proc.returncode
+            if len(stderr) > 0:
+                LOG.debug("Error {0}".format('\n'.join(stderr)))
+            raise Exception("{0}".format(cmd))
+        return stdout, proc.returncode
     except Exception as exep:
         if raise_exception:
             raise Exception("{0} failed: {1}".format(cmd, exep))

--- a/ister_test.py
+++ b/ister_test.py
@@ -516,7 +516,7 @@ def create_virtual_disk_good_meg():
     """Create disk with size specified in megabytes"""
     template = {"PartitionLayout": [{"size": "20000M", "disk": "vdisk_tmp"},
                                     {"size": "50M"}]}
-    command = "qemu-img create vdisk_tmp 20051M"
+    command = "dd if=/dev/zero of=vdisk_tmp bs=1024 count=20531240 seek=20531240"
     ister.create_virtual_disk(template)
     if command != COMMAND_RESULTS[0] or len(COMMAND_RESULTS) != 1:
         raise Exception("command to create image doesn't match expected "
@@ -528,7 +528,7 @@ def create_virtual_disk_good_gig():
     """Create disk with size specified in gigabytes"""
     template = {"PartitionLayout": [{"size": "20G", "disk": "vdisk_tmp"},
                                     {"size": "1G"}]}
-    command = "qemu-img create vdisk_tmp 21505M"
+    command = "dd if=/dev/zero of=vdisk_tmp bs=1024 count=22020136 seek=22020136"
     ister.create_virtual_disk(template)
     if command != COMMAND_RESULTS[0] or len(COMMAND_RESULTS) != 1:
         raise Exception("command to create image doesn't match expected "
@@ -539,7 +539,7 @@ def create_virtual_disk_good_gig():
 def create_virtual_disk_good_tera():
     """Create disk with size specified in terabytes"""
     template = {"PartitionLayout": [{"size": "1T", "disk": "vdisk_tmp"}]}
-    command = "qemu-img create vdisk_tmp 1048577M"
+    command = "dd if=/dev/zero of=vdisk_tmp bs=1024 count=1073741864 seek=1073741864"
     ister.create_virtual_disk(template)
     if command != COMMAND_RESULTS[0] or len(COMMAND_RESULTS) != 1:
         raise Exception("command to create image doesn't match expected "


### PR DESCRIPTION
Switch to dd instead of qemu-img for creating virtual disks. Also enable stderr output to be output to the console even if the program didn't exit with a non-zero return code.