### PR TITLE
Stop staticly salting users passwords

### DIFF
--- a/ister_gui.py
+++ b/ister_gui.py
@@ -2662,8 +2662,7 @@ class UserConfigurationStep(ProcessStep):
                 continue
         tmp = dict()
         tmp['username'] = self.edit_username.get_edit_text()
-        tmp['password'] = crypt.crypt(self.edit_password.get_edit_text(),
-                                      'aa')
+        tmp['password'] = crypt.crypt(self.edit_password.get_edit_text())
         tmp['sudo'] = self.sudo.get_state()
         self._set_fullname(tmp)
 


### PR DESCRIPTION
A static salt is doing nothing here (too small, publicly available),
use the default salt instead.