### PR TITLE
Set default uid to 1001 for consistency with gnome panel

### DIFF
--- a/ister.py
+++ b/ister.py
@@ -482,12 +482,9 @@ def create_account(user, target_dir):
     """
 
     os.makedirs(target_dir + "/home", exist_ok=True)
-    if user.get("uid"):
-        command = "useradd -U -m -u {0} {1}"\
-            .format(user["uid"], user["username"])
-    else:
-        command = "useradd -U -m {}".format(user["username"])
-
+    # default uid to 1001 if uid not present in user
+    command = "useradd -U -m -u {} {}".format(user.get("uid") or "1001",
+                                              user.get("username"))
     command += (" -p {0}".format(user["password"])
                 if user.get("password") else " -p ''")
 

--- a/ister_test.py
+++ b/ister_test.py
@@ -1623,7 +1623,7 @@ def chroot_open_class_bad_close():
 def create_account_good():
     """Create account no uid"""
     template = {"username": "user"}
-    commands = ["useradd -U -m user -p ''"]
+    commands = ["useradd -U -m -u 1001 user -p ''"]
     ister.create_account(template, "/tmp")
     commands_compare_helper(commands)
 


### PR DESCRIPTION
The gnome settings UI adds new users with the 1001 uid. Ister should be
consistent with the default desktop environment installed via the
desktops bundle.

Signed-off-by: Matthew Johnson <matthew.johnson@intel.com>