### PR TITLE
Enable users to enter fully qualified domain names

### DIFF
--- a/ister_gui.py
+++ b/ister_gui.py
@@ -816,9 +816,9 @@ class HostnameEdit(urwid.Edit):
     def keypress(self, size, key):
         """Manages key press event to validate input"""
         first = re.compile('[a-zA-Z0-9]')
-        rest = re.compile('[a-zA-Z0-9-]')
+        rest = re.compile('[a-zA-Z0-9-.]')
         # Only allow valid hostnames. Only letters, numbers,
-        # and '-' allowed.  Can't start with '-', Max length 63 """
+        # '.' and '-' allowed.  Can't start with '.' or '-', Max length 63 """
 
         i = len(self.get_edit_text())
 


### PR DESCRIPTION
Do not reject '.' characters in hostnames as a way to enable users to
enter a FQDN when entering their hostname.