### PR TITLE
Allow openssh-server to be installed through the gui

### DIFF
--- a/ister_gui.py
+++ b/ister_gui.py
@@ -2412,6 +2412,8 @@ class BundleSelectorStep(ProcessStep):
                          'desc': 'Popular text editors (terminal-based)'},
                         {'name': 'user-basic',
                          'desc': 'Captures most console work flows'},
+                        {'name': 'openssh-server',
+                         'desc': 'Secure shell server for remote login'},
                         {'name': 'desktop-autostart',
                          'desc': 'UI that automatically starts on boot'},
                         {'name': 'dev-utils',

--- a/maninstall.expect
+++ b/maninstall.expect
@@ -115,6 +115,7 @@ send -- "\t"
 send -- "\t"
 send -- "\t"
 send -- "\t"
+send -- "\t"
 # Next
 send -- "\r"
 expect -re ".*Network configuration.*"


### PR DESCRIPTION
Allow users to select the openssh-server through the ister_gui manual
bundle selection page.