### PR TITLE
Add option for moving statedir into targetdir

### DIFF
--- a/ister.py
+++ b/ister.py
@@ -1435,7 +1435,7 @@ def main():
         install_os(args)
     except Exception as exep:
         LOG.debug("Failed: {}".format(repr(exep)))
-        # todo: Add arg for loglevel to -v
+        # TODO: Add arg for loglevel to -v
         # And change this to trigger on DEBUG level
         if DEBUG:
             traceback.print_exc()

--- a/ister.py
+++ b/ister.py
@@ -423,6 +423,8 @@ def copy_os(args, template, target_dir):
     swupd_command += " --contenturl={0}".format(args.contenturl)
     swupd_command += " --versionurl={0}".format(args.versionurl)
     swupd_command += " --format={0}".format(args.format)
+    if args.fast_install:
+        args.statedir = "{0}/tmp/swupd".format(target_dir)
     swupd_command += " --statedir={0}".format(args.statedir)
     if args.cert_file:
         swupd_command += " -C {0}".format(args.cert_file)
@@ -440,6 +442,9 @@ def copy_os(args, template, target_dir):
         LOG.debug("https_proxy: {}".format(template["HTTPSProxy"]))
 
     run_command(swupd_command, environ=swupd_env, show_output=True)
+
+    if args.fast_install:
+        run_command("rm -rf {0}".format(args.statedir))
 
 
 class ChrootOpen(object):
@@ -1415,9 +1420,13 @@ def handle_options():
     parser.add_argument("-k", "--kcmdline", action="store",
                         default="/proc/cmdline",
                         help="File to inspect for kernel cmdline opts")
-    parser.add_argument("-S", "--statedir", action="store",
+    group = parser.add_mutually_exclusive_group(required=False)
+    group.add_argument("-S", "--statedir", action="store",
                         default="/var/lib/swupd",
                         help="Path to swupd state dir")
+    group.add_argument("-F", "--fast-install", action="store_true",
+                        default=False,
+                        help="Move swupd state dir inside image for a faster install")
     args = parser.parse_args()
     return args
 

--- a/ister.py
+++ b/ister.py
@@ -103,7 +103,7 @@ def run_command(cmd, raise_exception=True, log_output=True, environ=None,
                 LOG.debug(decoded_line)
 
         if proc.poll() and raise_exception:
-            if len(stderr) > 0:
+            if stderr:
                 LOG.debug("Error {0}".format('\n'.join(stderr)))
             raise Exception("{0}".format(cmd))
         return stdout, proc.returncode

--- a/ister_test.py
+++ b/ister_test.py
@@ -1366,6 +1366,7 @@ def copy_os_good():
     args.versionurl = "vtest"
     args.format = "formattest"
     args.statedir = "/statetest"
+    args.fast_install = False
     args.cert_file = None
     swupd_cmd = "swupd verify --install --path=/ --manifest=0 "              \
                 "--contenturl=ctest --versionurl=vtest --format=formattest " \
@@ -1394,6 +1395,7 @@ def copy_os_cert_good():
     args.versionurl = "vtest"
     args.format = "formattest"
     args.statedir = "/statetest"
+    args.fast_install = False
     args.cert_file = "/certtest"
     swupd_cmd = "swupd verify --install --path=/ --manifest=0 "              \
                 "--contenturl=ctest --versionurl=vtest --format=formattest " \
@@ -1427,6 +1429,7 @@ def copy_os_proxy_good():
     args.versionurl = "vtest"
     args.format = "formattest"
     args.statedir = "/statetest"
+    args.fast_install = False
     args.cert_file = None
     swupd_cmd = "swupd verify --install --path=/ --manifest=0 "              \
                 "--contenturl=ctest --versionurl=vtest --format=formattest " \
@@ -1463,6 +1466,7 @@ def copy_os_format_good():
     args.versionurl = "vtest"
     args.format = None
     args.statedir = "/statetest"
+    args.fast_install = False
     args.cert_file = None
     swupd_cmd = "swupd verify --install --path=/ --manifest=0 "        \
                 "--contenturl=ctest --versionurl=vtest --format=test " \
@@ -1493,6 +1497,7 @@ def copy_os_which_good():
     args.versionurl = "vtest"
     args.format = "formattest"
     args.statedir = "/statetest"
+    args.fast_install = False
     args.cert_file = None
     swupd_cmd = "swupd verify --install --path=/ --manifest=0 "              \
                 "--contenturl=ctest --versionurl=vtest --format=formattest " \
@@ -1502,6 +1507,36 @@ def copy_os_which_good():
                 True,
                 True]
     ister.copy_os(args, {"Version": 0, "DestinationType": ""}, "/")
+    ister.add_bundles = backup_add_bundles
+    shutil.which = backup_which
+    commands_compare_helper(commands)
+
+
+@run_command_wrapper
+def copy_os_fast_install_good():
+    """Check installer command with fast install option"""
+    backup_add_bundles = ister.add_bundles
+    ister.add_bundles = lambda x, y: None
+    backup_which = shutil.which
+    shutil.which = lambda x: False
+
+    def args():
+        """args empty object"""
+        pass
+    args.contenturl = "ctest"
+    args.versionurl = "vtest"
+    args.format = "formattest"
+    args.statedir = "/statetest"
+    args.fast_install = True
+    args.cert_file = None
+    swupd_cmd = "swupd verify --install --path=/tmp --manifest=0 "           \
+                "--contenturl=ctest --versionurl=vtest --format=formattest " \
+                "--statedir=/tmp/tmp/swupd"
+    commands = [swupd_cmd,
+                True,
+                True,
+                "rm -rf /tmp/tmp/swupd"]
+    ister.copy_os(args, {"Version": 0, "DestinationType": ""}, "/tmp")
     ister.add_bundles = backup_add_bundles
     shutil.which = backup_which
     commands_compare_helper(commands)
@@ -1532,6 +1567,7 @@ def copy_os_physical_good():
     args.versionurl = "vtest"
     args.format = "formattest"
     args.statedir = "/statetest"
+    args.fast_install = False
     args.cert_file = None
     swupd_cmd = "swupd verify --install --path=/ --manifest=0 "              \
                 "--contenturl=ctest --versionurl=vtest --format=formattest " \
@@ -5154,6 +5190,7 @@ if __name__ == '__main__':
         copy_os_proxy_good,
         copy_os_format_good,
         copy_os_which_good,
+        copy_os_fast_install_good,
         copy_os_physical_good,
         chroot_open_class_good,
         chroot_open_class_bad_open,


### PR DESCRIPTION
The current install approach favors disk space by allowing for the state
dir to exist outside of the target dir.  However, the two directories
can exist across block device boundaries.  To favor time to install,
adding an option to relocate the state dir into the target dir so they
are located within the same block device.  This can reduce install time
by as much as 60%.  Once the install has completed, the state dir is
removed from the target dir.

This has a couple of side effects.  When this option is used, the
template needs to allocate space for the state dir in addition to actual
content.  Additionally, this option cannot be used in conjunction with
the statedir option, as the state dir in this case is automatically
derived.  Because of these side effects, this option is not enabled by
default.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>