### PR TITLE
Add support for installing content with dnf

### DIFF
--- a/dnf-post-update.sh
+++ b/dnf-post-update.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+"$1"/usr/bin/update-helper "$1"
+"$1"/usr/bin/clr-boot-manager update -p "$1"

--- a/ister.py
+++ b/ister.py
@@ -400,29 +400,21 @@ def add_bundles(template, target_dir):
     LOG.info("Installing {} bundles (and dependencies)...".format(index + 1))
 
 
-def get_current_format():
-    """Find the format id (if any) on the current system
-    """
-    frmt = ""
-    with open("/usr/share/defaults/swupd/format", "r") as format_file:
-        frmt = format_file.read().strip()
-    return frmt
-
-
 def copy_os(args, template, target_dir):
     """Wrapper for running install command
     """
     LOG.info("Starting swupd. May take several minutes")
-    if not args.format:
-        args.format = get_current_format()
     add_bundles(template, target_dir)
     swupd_command = "swupd verify --install --path={0} " \
                     "--manifest={1}".format(target_dir, template["Version"])
     if shutil.which("stdbuf"):
         swupd_command = "stdbuf -o 0 {0}".format(swupd_command)
-    swupd_command += " --contenturl={0}".format(args.contenturl)
-    swupd_command += " --versionurl={0}".format(args.versionurl)
-    swupd_command += " --format={0}".format(args.format)
+    if args.contenturl:
+        swupd_command += " --contenturl={0}".format(args.contenturl)
+    if args.versionurl:
+        swupd_command += " --versionurl={0}".format(args.versionurl)
+    if args.format:
+        swupd_command += " --format={0}".format(args.format)
     if args.fast_install:
         args.statedir = "{0}/tmp/swupd".format(target_dir)
     swupd_command += " --statedir={0}".format(args.statedir)
@@ -1409,10 +1401,10 @@ def handle_options():
                         default=None,
                         help="Path to template file to use")
     parser.add_argument("-V", "--versionurl", action="store",
-                        default="https://cdn.download.clearlinux.org/update",
+                        default=None,
                         help="URL to use for looking for update versions")
     parser.add_argument("-C", "--contenturl", action="store",
-                        default="https://cdn.download.clearlinux.org/update",
+                        default=None,
                         help="URL to use for looking for update content")
     parser.add_argument("-f", "--format", action="store", default=None,
                         help="format to use for looking for update content")

--- a/ister.py
+++ b/ister.py
@@ -1406,7 +1406,8 @@ def handle_options():
     parser.add_argument("-C", "--contenturl", action="store",
                         default=None,
                         help="URL to use for looking for update content")
-    parser.add_argument("-f", "--format", action="store", default=None,
+    parser.add_argument("-f", "--format", action="store",
+                        default=None,
                         help="format to use for looking for update content")
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Output logging to console stream")
@@ -1424,7 +1425,6 @@ def handle_options():
                         default="/var/lib/swupd",
                         help="Path to swupd state dir")
     group.add_argument("-F", "--fast-install", action="store_true",
-                        default=False,
                         help="Move swupd state dir inside image for a faster install")
     args = parser.parse_args()
     return args

--- a/ister_test.py
+++ b/ister_test.py
@@ -3290,7 +3290,7 @@ def handle_options_good():
     # Test short options first
     sys.argv = ["ister.py", "-c", "cfg", "-t", "tpt", "-C", "/", "-V", "/",
                 "-f", "1", "-v", "-l", "log", "-L", "debug", "-S", "/",
-                "-s", "./cert"]
+                "-s", "./cert", "-k", "/cmdline"]
     try:
         args = ister.handle_options()
     except Exception:
@@ -3313,13 +3313,18 @@ def handle_options_good():
         raise Exception("Failed to correctly set short loglevel")
     if args.statedir != "/":
         raise Exception("Failed to correctly set short state dir")
+    if args.fast_install:
+        raise Exception("Failed to correctly set fast install")
     if args.cert_file != "./cert":
         raise Exception("Failed to correctly set short cert file")
+    if args.kcmdline != "/cmdline":
+        raise Exception("Failed to correctly set kcmdline")
+
     # Test long options next
     sys.argv = ["ister.py", "--config-file=cfg", "--template-file=tpt",
                 "--contenturl=/", "--versionurl=/", "--format=1", "--verbose",
                 "--logfile=log", "--loglevel=debug", "--statedir=/",
-                "--cert-file=./cert"]
+                "--cert-file=./cert", "--kcmdline=/cmdline"]
     try:
         args = ister.handle_options()
     except Exception:
@@ -3342,8 +3347,13 @@ def handle_options_good():
         raise Exception("Failed to correctly set long loglevel")
     if args.statedir != "/":
         raise Exception("Failed to correctly set long state dir")
+    if args.fast_install:
+        raise Exception("Failed to correctly set long fast install")
     if args.cert_file != "./cert":
         raise Exception("Failed to correctly set long cert file")
+    if args.kcmdline != "/cmdline":
+        raise Exception("Failed to correctly set long kcmdline")
+
     # Test default options
     sys.argv = ["ister.py"]
     try:
@@ -3368,8 +3378,12 @@ def handle_options_good():
         raise Exception("Incorrect default loglevel set")
     if args.statedir != "/var/lib/swupd":
         raise Exception("Incorrect default state dir set")
+    if args.fast_install:
+        raise Exception("Incorrect default fast install set")
     if args.cert_file:
         raise Exception("Incorrect default cert file set")
+    if args.kcmdline != "/proc/cmdline":
+        raise Exception("Incorrect default kcmdline set")
 
 
 def handle_logging_good():

--- a/ister_test.py
+++ b/ister_test.py
@@ -1321,20 +1321,6 @@ def add_bundles_good():
     commands_compare_helper(commands)
 
 
-@open_wrapper("good", "1\n")
-def get_current_format_good():
-    """Ensure correct data read from format file"""
-    global COMMAND_RESULTS
-    COMMAND_RESULTS = []
-    commands = ["/usr/share/defaults/swupd/format",
-                "r",
-                "read",
-                "1"]
-    frmt = ister.get_current_format()
-    COMMAND_RESULTS.append(frmt)
-    commands_compare_helper(commands)
-
-
 @open_wrapper("good", "")
 @makedirs_wrapper("good")
 def set_hostname_good():
@@ -1455,8 +1441,6 @@ def copy_os_format_good():
     ister.add_bundles = lambda x, y: None
     backup_which = shutil.which
     shutil.which = lambda x: False
-    backup_get_current_format = ister.get_current_format
-    ister.get_current_format = lambda: "test"
 
     def args():
         """args empty object"""
@@ -1464,12 +1448,12 @@ def copy_os_format_good():
 
     args.contenturl = "ctest"
     args.versionurl = "vtest"
-    args.format = None
+    args.format = "formattest"
     args.statedir = "/statetest"
     args.fast_install = False
     args.cert_file = None
     swupd_cmd = "swupd verify --install --path=/ --manifest=0 "        \
-                "--contenturl=ctest --versionurl=vtest --format=test " \
+                "--contenturl=ctest --versionurl=vtest --format=formattest " \
                 "--statedir=/statetest"
     commands = [swupd_cmd,
                 True,
@@ -1477,7 +1461,6 @@ def copy_os_format_good():
     ister.copy_os(args, {"Version": 0, "DestinationType": ""}, "/")
     ister.add_bundles = backup_add_bundles
     shutil.which = backup_which
-    ister.get_current_format = backup_get_current_format
     commands_compare_helper(commands)
 
 
@@ -3371,9 +3354,9 @@ def handle_options_good():
         raise Exception("Incorrect default config file set")
     if args.template_file:
         raise Exception("Incorrect default template file set")
-    if args.contenturl != "https://cdn.download.clearlinux.org/update":
+    if args.contenturl:
         raise Exception("Incorrect default contenturl set")
-    if args.versionurl != "https://cdn.download.clearlinux.org/update":
+    if args.versionurl:
         raise Exception("Incorrect default versionurl set")
     if args.format:
         raise Exception("Incorrect default format set")
@@ -5214,7 +5197,6 @@ if __name__ == '__main__':
         setup_mounts_bad,
         setup_mounts_good_units,
         add_bundles_good,
-        get_current_format_good,
         set_hostname_good,
         copy_os_good,
         copy_os_cert_good,


### PR DESCRIPTION
In test scenarios, work to create a swupd update stream is not needed
and increases image generation time.  If content for a test scenario can
be supplied as a package repository, then dnf can be used to do an
install of packages in the same way mixer generates chroots.

To support a define-and-run approach with ister, template files may
define an additional "PackageManager" key, which may be either "dnf" or
"swupd", if not defined to preserve backwards compatbility.  In the case
where the package manager is swupd, the list of bundles remains the same
as it is today.  In the case where the package manager is dnf, the
bundle list is treated as a package list that is used during a dnf
install.

Much like how content and version URLs may be passed at the command line
for swupd, to pass package repository URLs, which there may be multiple,
a DNF configuration file must be passed instead with the new
--dnf-config option.

To mimic how swupd works after installing content, update triggers are
run if they exist.  Because using DNF makes ister distro-agnostic,
opting to make the image bootable by using a post non-chroot script as
opposed to calling clr-boot-manager update directly.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>