### PR TITLE
Add reference JSON for virtual images

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,6 +2,6 @@ systemdsystemunitdir = @SYSTEMD_SYSTEMUNITDIR@
 dist_systemdsystemunit_DATA = ister.service ister-provision.service
 
 statelessdir = $(datarootdir)/defaults/$(PACKAGE)
-dist_stateless_DATA = ister.conf ister.json
+dist_stateless_DATA = ister.conf ister.json release-image-config.json
 
 dist_bin_SCRIPTS = ister.py ister_gui.py


### PR DESCRIPTION
When getting going with ister and Clear, new users will expect to be
able to look in /usr/share for reference implementations of how to do
certain tasks.  Providing a reference for physical images and virtual
images will help users get going more quickly.  This would also allow
public documentation to be updated to let users copy files they already
have locally to keep them going with their task.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>