### PR TITLE
Do not run ldconfig in post install nonchroot

### DIFF
--- a/ister.py
+++ b/ister.py
@@ -720,9 +720,6 @@ def post_install_nonchroot(template, target_dir):
 
     The mount root for the install is passed as an argument to each script.
     """
-    # Always run some post install jobs
-    run_command("ldconfig -r {}".format(target_dir))
-
     if not template.get("PostNonChroot"):
         return
     LOG.info("Running post non-chroot scripts")

--- a/ister_test.py
+++ b/ister_test.py
@@ -2103,8 +2103,7 @@ def pre_install_shell_good():
 @run_command_wrapper
 def post_install_nonchroot_good():
     """Test post non-chroot install script execution"""
-    commands = ["ldconfig -r /tmp",
-                "file1 /tmp"]
+    commands = ["file1 /tmp"]
     ister.post_install_nonchroot({"PostNonChroot": ["file1"]}, "/tmp")
     commands_compare_helper(commands)
 


### PR DESCRIPTION
Ister and swupd run ldconfig after an install redundantly.  We want to
have ister default to letting swupd run its post install triggers, or
having a user run these manually in the same way that swupd would with
their post script, rather than replicating part of them itself.  Running
ldconfig differently in both instances has the side-effect of removing
broken library symlinks from an install.

Signed-off-by: George T Kramer <george.t.kramer@intel.com>