### PR TITLE
Adding custom mirror URL fields to installer

### DIFF
--- a/ister.py
+++ b/ister.py
@@ -453,10 +453,18 @@ def copy_os_swupd(args, template, target_dir):
     cmd = "swupd verify --install"
     cmd += " --path={0}".format(target_dir)
     cmd += " --manifest={0}".format(template["Version"])
-    if args.contenturl:
-        cmd += " --contenturl={0}".format(args.contenturl)
-    if args.versionurl:
-        cmd += " --versionurl={0}".format(args.versionurl)
+    if args.contenturl or template.get("MirrorURL"):
+        if template.get("MirrorURL"):
+            cmd_mirror_url =  template.get("MirrorURL")
+        else:
+            cmd_mirror_url =  args.contenturl
+        cmd += " --contenturl={0}".format(cmd_mirror_url)
+    if args.versionurl or template.get("VersionURL"):
+        if template.get("VersionURL"):
+            cmd_version_url =  template.get("VersionURL")
+        else:
+            cmd_version_url =  args.versionurl
+        cmd += " --versionurl={0}".format(cmd_version_url)
     if args.format:
         cmd += " --format={0}".format(args.format)
     cmd += " --statedir={0}".format(args.statedir)
@@ -662,6 +670,30 @@ def set_hostname(template, target_dir):
 
     with open(path + "hostname", "w") as file:
         file.write(hostname)
+
+
+def set_mirror_url(target_mirror_url, target_dir):
+    """Writes custom mirror url to <target disk>/etc/swupd/mirror_contenturl
+    """
+    LOG.info("Setting custom mirror url")
+    path = '{0}/etc/swupd/'.format(target_dir)
+    if not os.path.exists(path):
+        os.makedirs(path)
+
+    with open(path + "mirror_contenturl", "w") as file:
+        file.write(target_mirror_url)
+
+
+def set_mirror_version_url(target_mirror_version_url, target_dir):
+    """Writes custom mirror version url to <target disk>/etc/swupd/mirror_versionurl
+    """
+    LOG.info("Setting custom mirror version url")
+    path = '{0}/etc/swupd/'.format(target_dir)
+    if not os.path.exists(path):
+        os.makedirs(path)
+
+    with open(path + "mirror_versionurl", "w") as file:
+        file.write(target_mirror_version_url)
 
 
 def set_static_configuration(template, target_dir):
@@ -1135,6 +1167,26 @@ def validate_proxy_url_template(proxy):
         raise Exception("Invalid proxy url: {}".format(proxy))
 
 
+def validate_mirror_url_template(mirror):
+    """Attempt to verify the mirror setting is valid
+
+    This function will raise an Exception on finding an error.
+    """
+    url = urlparse(mirror)
+    if not (url.scheme and url.netloc):
+        raise Exception("Invalid mirror url: {}".format(mirror))
+
+
+def validate_mirror_version_url_template(version):
+    """Attempt to verify the version setting is valid
+
+    This function will raise an Exception on finding an error.
+    """
+    url = urlparse(version)
+    if not (url.scheme and url.netloc):
+        raise Exception("Invalid version url: {}".format(version))
+
+
 def validate_cmdline_template(cmdline):
     """Attempt to verify the cmdline configuration
 
@@ -1180,6 +1232,10 @@ def validate_template(template):
         validate_proxy_url_template(template["HTTPSProxy"])
     if template.get("HTTPProxy"):
         validate_proxy_url_template(template["HTTPProxy"])
+    if template.get("MirrorURL"):
+        validate_mirror_url_template(template["MirrorURL"])
+    if template.get("VersionURL"):
+        validate_mirror_version_url_template(template["VersionURL"])
     if template.get("cmdline"):
         validate_cmdline_template(template["cmdline"])
     LOG.debug("Configuration is valid:")
@@ -1422,6 +1478,12 @@ def install_os(args, template):
         copy_os(args, template, target_dir)
         add_users(template, target_dir)
         set_hostname(template, target_dir)
+        if template.get("MirrorURL"):
+            cmd_mirror_url =  template.get("MirrorURL")
+            set_mirror_url(cmd_mirror_url,target_dir)
+        if template.get("VersionURL"):
+            cmd_version_url =  template.get("VersionURL")
+            set_mirror_version_url(cmd_version_url,target_dir)
         set_static_configuration(template, target_dir)
         set_kernel_cmdline_appends(template, target_dir)
         if template.get("IsterCloudInitSvc"):

--- a/ister.py
+++ b/ister.py
@@ -453,18 +453,10 @@ def copy_os_swupd(args, template, target_dir):
     cmd = "swupd verify --install"
     cmd += " --path={0}".format(target_dir)
     cmd += " --manifest={0}".format(template["Version"])
-    if args.contenturl or template.get("MirrorURL"):
-        if template.get("MirrorURL"):
-            cmd_mirror_url =  template.get("MirrorURL")
-        else:
-            cmd_mirror_url =  args.contenturl
-        cmd += " --contenturl={0}".format(cmd_mirror_url)
-    if args.versionurl or template.get("VersionURL"):
-        if template.get("VersionURL"):
-            cmd_version_url =  template.get("VersionURL")
-        else:
-            cmd_version_url =  args.versionurl
-        cmd += " --versionurl={0}".format(cmd_version_url)
+    if args.contenturl:
+        cmd += " --contenturl={0}".format(args.contenturl)
+    if args.versionurl:
+        cmd += " --versionurl={0}".format(args.versionurl)
     if args.format:
         cmd += " --format={0}".format(args.format)
     cmd += " --statedir={0}".format(args.statedir)
@@ -672,9 +664,13 @@ def set_hostname(template, target_dir):
         file.write(hostname)
 
 
-def set_mirror_url(target_mirror_url, target_dir):
+def set_mirror_url(template, target_dir):
     """Writes custom mirror url to <target disk>/etc/swupd/mirror_contenturl
     """
+    target_mirror_url = template.get("MirrorURL")
+    if not target_mirror_url:
+        return
+
     LOG.info("Setting custom mirror url")
     path = '{0}/etc/swupd/'.format(target_dir)
     if not os.path.exists(path):
@@ -684,9 +680,13 @@ def set_mirror_url(target_mirror_url, target_dir):
         file.write(target_mirror_url)
 
 
-def set_mirror_version_url(target_mirror_version_url, target_dir):
+def set_mirror_version_url(template, target_dir):
     """Writes custom mirror version url to <target disk>/etc/swupd/mirror_versionurl
     """
+    target_mirror_version_url = template.get("VersionURL")
+    if not target_mirror_version_url:
+        return
+
     LOG.info("Setting custom mirror version url")
     path = '{0}/etc/swupd/'.format(target_dir)
     if not os.path.exists(path):
@@ -1478,12 +1478,8 @@ def install_os(args, template):
         copy_os(args, template, target_dir)
         add_users(template, target_dir)
         set_hostname(template, target_dir)
-        if template.get("MirrorURL"):
-            cmd_mirror_url =  template.get("MirrorURL")
-            set_mirror_url(cmd_mirror_url,target_dir)
-        if template.get("VersionURL"):
-            cmd_version_url =  template.get("VersionURL")
-            set_mirror_version_url(cmd_version_url,target_dir)
+        set_mirror_url(template,target_dir)
+        set_mirror_version_url(template,target_dir)
         set_static_configuration(template, target_dir)
         set_kernel_cmdline_appends(template, target_dir)
         if template.get("IsterCloudInitSvc"):

--- a/ister_gui.py
+++ b/ister_gui.py
@@ -3358,6 +3358,10 @@ class Installation(object):
             {'name': 'contenturl', 'out': '--contenturl={0}'},
             {'name': 'versionurl', 'out': '--versionurl={0}'},
             {'name': 'format', 'out': '--format={0}'}]
+        if self.installation_d.get('VersionURL'):
+            self.args['versionurl'] = self.installation_d.get('VersionURL')
+        if self.installation_d.get('MirrorURL'):
+            self.args['contenturl'] = self.installation_d.get('MirrorURL')
         ister_cmd = [item['out'].format(self.args[item['name']])
                  for item in supported if self.args[item['name']] is not None]
         ister_log = '/var/log/ister.log'

--- a/ister_test.py
+++ b/ister_test.py
@@ -3245,6 +3245,63 @@ def validate_proxy_url_template_bad():
         raise Exception("Incorrectly validated the following url(s): "
                         "{}".format(", ".join(error)))
 
+def validate_mirror_url_template_good():
+    ister.validate_mirror_url_template("https://download.clearlinux.org/update/")
+
+
+def validate_mirror_url_template_bad():
+    error = []
+    try:
+        ister.validate_mirror_url_template("httpsdownload.clearlinux.org/update/")
+        error.append("httpsdownload.clearlinux.org/update/")
+    except Exception:
+        pass
+
+    try:
+        ister.validate_mirror_url_template("not a url")
+        error.append("not a url")
+    except Exception:
+        pass
+
+    try:
+        ister.validate_mirror_url_template("clear.com")
+        error.append("clear.com")
+    except Exception:
+        pass
+
+    if error:
+        raise Exception("Incorrectly validated the following url(s): "
+                        "{}".format(", ".join(error)))
+
+
+def validate_mirror_version_url_template_good():
+    ister.validate_mirror_version_url_template("https://download.clearlinux.org/update/")
+
+
+def validate_mirror_version_url_template_bad():
+    error = []
+    try:
+        ister.validate_mirror_version_url_template("httpsdownload.clearlinux.org/update/")
+        error.append("httpsdownload.clearlinux.org/update/")
+    except Exception:
+        pass
+
+    try:
+        ister.validate_mirror_version_url_template("not a url")
+        error.append("not a url")
+    except Exception:
+        pass
+
+    try:
+        ister.validate_mirror_version_url_template("clear.com")
+        error.append("clear.com")
+    except Exception:
+        pass
+
+    if error:
+        raise Exception("Incorrectly validated the following url(s): "
+                        "{}".format(", ".join(error)))
+
 
 def validate_template_good():
     """Good validate_template"""
@@ -4897,6 +4954,92 @@ def gui_set_proxy():
             raise Exception("Proxy not set properly in config")
 
 
+def gui_set_mirror():
+    """
+    Setting the mirror URL in the gui results in the mirror URL getting stored
+    in the template (config)
+    """
+    import time
+
+    class Edit():
+        """mock uwrid.Edit class"""
+        def __init__(self, edit_text):
+            self.edit_text = edit_text
+
+        def get_edit_text(self):
+            return self.edit_text
+
+    def mock_sleep(sec):
+        """mock_sleep wrapper so the tests run faster"""
+        del sec
+
+    def mock_service_ready():
+        return True
+
+    sleep_backup = time.sleep
+    time.sleep = mock_sleep
+    service_ready_backup = ister_gui.network_service_ready
+    ister_gui.network_service_ready = mock_service_ready
+
+    netreq = ister_gui.NetworkRequirements(1, 1, "", "")
+    netreq.config = {}
+    netreq.content_url_alt = Edit("https://download.clearlinux.org/update/")
+    try:
+        netreq._set_mirror(None)
+    except Exception:
+        # this method always exits with an exception (urwid.ExitMainLoop)
+        pass
+
+    time.sleep = sleep_backup
+    ister_gui.network_service_ready = service_ready_backup
+    if "MirrorURL" in netreq.config:
+        if netreq.config["MirrorURL"] != "https://download.clearlinux.org/update/":
+            raise Exception("Mirror URL not set properly in config")
+
+
+def gui_set_version():
+    """
+    Setting the version URL in the gui results in the version URL getting stored
+    in the template (config)
+    """
+    import time
+
+    class Edit():
+        """mock uwrid.Edit class"""
+        def __init__(self, edit_text):
+            self.edit_text = edit_text
+
+        def get_edit_text(self):
+            return self.edit_text
+
+    def mock_sleep(sec):
+        """mock_sleep wrapper so the tests run faster"""
+        del sec
+
+    def mock_service_ready():
+        return True
+
+    sleep_backup = time.sleep
+    time.sleep = mock_sleep
+    service_ready_backup = ister_gui.network_service_ready
+    ister_gui.network_service_ready = mock_service_ready
+
+    netreq = ister_gui.NetworkRequirements(1, 1, "", "")
+    netreq.config = {}
+    netreq.content_url_alt = Edit("https://download.clearlinux.org/update/")
+    try:
+        netreq._set_version(None)
+    except Exception:
+        # this method always exits with an exception (urwid.ExitMainLoop)
+        pass
+
+    time.sleep = sleep_backup
+    ister_gui.network_service_ready = service_ready_backup
+    if "VersionURL" in netreq.config:
+        if netreq.config["VersionURL"] != "https://download.clearlinux.org/update/":
+            raise Exception("Version URL not set properly in config")
+
+
 def gui_set_fullname_fname_lname_present():
     """
     Set the user's full name in the gui with first and last names present
@@ -5693,12 +5836,18 @@ if __name__ == '__main__':
         gui_network_connection_curl_exception_version_url,
         gui_static_configuration,
         gui_set_proxy,
+        gui_set_mirror,
+        gui_set_version,
         gui_set_fullname_fname_lname_present,
         gui_set_fullname_fname_present,
         gui_set_fullname_lname_present,
         gui_set_fullname_none_present,
         validate_proxy_url_template_good,
         validate_proxy_url_template_bad,
+        validate_mirror_url_template_good,
+        validate_mirror_url_template_bad,
+        validate_mirror_version_url_template_good,
+        validate_mirror_version_url_template_bad,
         gui_set_hw_time,
         gui_find_current_disk_success,
         gui_find_current_disk_failure,


### PR DESCRIPTION
Summary of changes:

- set argument default to None when cmdline value not specified (no hardcoding)
- allow user to optionally modify values independently for the content or version URL's to alternate mirrors
- if there is a URL modification, or a command line value that verify as 'good', ister will write the values to the target OS