### PR TITLE
ister_gui: Fix bug during Bundles initialization

### DIFF
--- a/ister_gui.py
+++ b/ister_gui.py
@@ -3323,9 +3323,6 @@ class Installation(object):
         """Starts up the installer ui"""
         pprint.PrettyPrinter(indent=4)
         step = self.start
-        # initiate the bundles list at the start, not in a screen, so it does
-        # not get overwritten when a user returns to that screen.
-        self.installation_d['Bundles'] = list()
         i = 0
         while not isinstance(step, RunInstallation):
             action = step.handler(self.installation_d)


### PR DESCRIPTION
The list is populate during the creation of the installation object with
the bundle list provided by the template found at /etc/ister.json,
inject there during the manufacturing of the installer image. Just after
that is was being cleared and therefore the templates list was never
respected.

That initialization is enough for the code to properly work since at
that point the code is executed only once, no matter if the user rolled
back some screens.

Signed-off-by: Murilo Belluzzo <murilo.belluzzo@intel.com>