### PR TITLE
Improve error messages

### DIFF
--- a/ister.py
+++ b/ister.py
@@ -62,9 +62,6 @@ import pycryptsetup
 
 LOG = None
 
-DEBUG = False
-
-
 def run_command(cmd, raise_exception=True, log_output=True, environ=None,
                 show_output=False, shell=False):
     """

--- a/ister.py
+++ b/ister.py
@@ -1611,9 +1611,7 @@ def main():
         install_os(args, template)
     except Exception as exep:
         LOG.debug("Failed: {}".format(repr(exep)))
-        # TODO: Add arg for loglevel to -v
-        # And change this to trigger on DEBUG level
-        if DEBUG:
+        if args.loglevel == "debug":
             traceback.print_exc()
         sys.exit(-1)
     LOG.info("Successful installation")

--- a/ister.py
+++ b/ister.py
@@ -1610,9 +1610,9 @@ def main():
         template = get_template(configuration["template"])
         install_os(args, template)
     except Exception as exep:
-        LOG.debug("Failed: {}".format(repr(exep)))
         if args.loglevel == "debug":
             traceback.print_exc()
+        LOG.error("Failed: {}".format(repr(exep)))
         sys.exit(-1)
     LOG.info("Successful installation")
     sys.exit(0)


### PR DESCRIPTION
It is hard to diagnose ister failures because of 2 reasons:

1. The stacktrace is hidden. Let's have it when using the debug loglevel.
2. The error message is hidden. Let's always have it - users will appreciate more visibility into the issue even when loglevel is non-debug.