### PR TITLE
Changing root user

### DIFF
--- a/ister.py
+++ b/ister.py
@@ -530,6 +530,7 @@ class ChrootOpen(object):
         try:
             self.old_root = os.open("/", os.O_RDONLY)
             os.chroot(self.target_dir)
+            os.chdir("/")
         except Exception:
             raise Exception("Unable to setup chroot to create users")
 

--- a/ister.py
+++ b/ister.py
@@ -614,7 +614,7 @@ def add_user_key(user, target_dir):
     akey_path = os.path.join(sshdir, "authorized_keys")
     with ChrootOpen(target_dir) as _:
         try:
-            os.makedirs(sshdir, mode=0o0700)
+            os.makedirs(sshdir, mode=0o0700, exist_ok=True)
             pwinfo = pwd.getpwnam(user["username"])
             uid = pwinfo[2]
             gid = pwinfo[3]

--- a/ister.py
+++ b/ister.py
@@ -67,9 +67,9 @@ LOG = None
 def run_command(cmd, raise_exception=True, log_output=True, environ=None,
                 show_output=False, shell=False):
     """
-    Execute given command in a subprocess and return a (stdout, exitcode) tuple,
-    where 'stdout' is the standard output of the command and 'exitcode' is the
-    exit status.
+    Execute given command in a subprocess and return a (stdout, stderr,
+    exitcode) tuple, where 'stdout' is the standard output of the command,
+    'stderr' is the standard error, and 'exitcode' is the exit status.
 
     This function will raise an Exception if the command fails unless
     raise_exception is False.
@@ -111,7 +111,7 @@ def run_command(cmd, raise_exception=True, log_output=True, environ=None,
             if output[1]:
                 LOG.debug("Error {0}".format('\n'.join(output[1])))
             raise Exception("{0}".format(cmd))
-        return output[0], proc.returncode
+        return output[0], output[1], proc.returncode
     except Exception as exep:
         if raise_exception:
             raise Exception("{0} failed: {1}".format(cmd, exep))
@@ -1345,7 +1345,7 @@ def get_iface_for_host(host):
     cmd = "ip route show to match {0}".format(ip_addr)
     iface = None
 
-    output, ret = run_command(cmd)
+    output, _, ret = run_command(cmd)
     LOG.debug("Output from ip route show...")
     LOG.debug(output)
     if ret == 0:

--- a/ister_test.py
+++ b/ister_test.py
@@ -1915,7 +1915,7 @@ def chroot_open_class_bad_close():
 def create_account_good():
     """Create account no uid"""
     template = {"username": "user"}
-    commands = ["useradd -U -m user -p ''"]
+    commands = ["useradd -U -m -p '' user", False]
     ister.create_account(template, "/tmp")
     commands_compare_helper(commands)
 
@@ -1925,7 +1925,7 @@ def create_account_good():
 def create_account_good_uid():
     """Create account with uid"""
     template = {"username": "user", "uid": "1000"}
-    commands = ["useradd -U -m -u 1000 user -p ''"]
+    commands = ["useradd -U -m -p '' -u 1000 user", False]
     ister.create_account(template, "/tmp")
     commands_compare_helper(commands)
 

--- a/ister_test.py
+++ b/ister_test.py
@@ -1948,7 +1948,6 @@ def add_user_key_good():
                 "/home/user/.ssh/authorized_keys",
                 "a",
                 "public",
-                "close",
                 "/home/user/.ssh/authorized_keys",
                 1000,
                 1000]

--- a/ister_test.py
+++ b/ister_test.py
@@ -1930,6 +1930,24 @@ def create_account_good_uid():
     ister.create_account(template, "/tmp")
     commands_compare_helper(commands)
 
+@run_command_wrapper
+@chroot_open_wrapper("silent")
+def create_account_existing():
+    """Create account with uid"""
+    backup_run_command = ister.run_command
+
+    def mock_run_command(cmd, **kwargs):
+        """mock_run_command for emoulateing useradd failure"""
+        result = backup_run_command(cmd, **kwargs)
+        return ["", "User already exists", 9]
+
+    ister.run_command = mock_run_command
+    template = {"username": "user", "uid": "1000"}
+    commands = ["useradd -U -m -p '' -u 1000 user", False,
+                "usermod -p '' -u 1000 user"]
+    ister.create_account(template, "/tmp")
+    commands_compare_helper(commands)
+    ister.run_command = backup_run_command
 
 @chroot_open_wrapper("silent")
 @open_wrapper("good", "")
@@ -5807,6 +5825,7 @@ if __name__ == '__main__':
         chroot_open_class_bad_close,
         create_account_good,
         create_account_good_uid,
+        create_account_existing,
         add_user_key_good,
         add_user_key_bad,
         setup_sudo_good,

--- a/ister_test.py
+++ b/ister_test.py
@@ -1850,6 +1850,7 @@ def chroot_open_class_good():
                 os.O_RDONLY,
                 "/tmp",
                 "/",
+                "/",
                 ".",
                 "/"]
     with ister.ChrootOpen("/tmp") as dest:

--- a/ister_test.py
+++ b/ister_test.py
@@ -206,6 +206,7 @@ def run_command_wrapper(func):
                 COMMAND_RESULTS.append(True)
             if shell:
                 COMMAND_RESULTS.append(True)
+            return [], [], 0
         global COMMAND_RESULTS
         COMMAND_RESULTS = []
         run_command = ister.run_command

--- a/ister_test.py
+++ b/ister_test.py
@@ -1941,7 +1941,7 @@ def add_user_key_good():
     commands = ["root",
                 "/home/user/.ssh",
                 448,
-                False,
+                True,
                 "user",
                 "/home/user/.ssh",
                 1000,

--- a/ister_test.py
+++ b/ister_test.py
@@ -1364,7 +1364,7 @@ def setup_mounts_good_units():
     def mock_run_command(cmd, *_):
         """mock run for setup mounts test"""
         COMMAND_RESULTS.append(cmd)
-        return (["", "X"],)
+        return (["", "X"], [], 0)
 
     def mock_listdir(_):
         return ['sda', 'sda1']
@@ -4196,7 +4196,7 @@ def get_iface_for_host_good():
     def mock_run_command(cmd):
         """ yield result of ip show route... """
         return ["default via 192.168.1.1 dev enp0s25 proto "
-                "static metric 600"], 0
+                "static metric 600"], [], 0
 
     gethostbyname_orig = socket.gethostbyname
     run_command_orig = ister.run_command
@@ -4222,7 +4222,7 @@ def get_iface_for_host_bad_no_route():
 
     def mock_run_command(cmd):
         """ ip show route runs into error """
-        return ["error"], 1
+        return ["error"], [], 1
 
     gethostbyname_orig = socket.gethostbyname
     run_command_orig = ister.run_command
@@ -4247,7 +4247,7 @@ def get_iface_for_host_bad_hostname():
 
     def mock_run_command(cmd):
         """ Result of ip show route on empty host... """
-        return ["Error: an inet prefix is expected rather than \"\"."], 1
+        return ["Error: an inet prefix is expected rather than \"\"."], [], 1
 
     gethostbyname_orig = socket.gethostbyname
     run_command_orig = ister.run_command


### PR DESCRIPTION
This pull requests makes it possible to change the 'root' user via 'ister.json', for example change root password and install root user SSH key. On top of this, the pull request fixes few bugs and introduces few improvements.

My use-case is the following. I have a SUT (System Under Test) in a fully isolated environment. I want my fully automated and unattended installation to set a pre-defined root password, root SSH key, and enable root SSH login. As simple as this. And I do not want to bring up 'cloud-init' server just for this simple purpose.

Here is the ister.json template that I use. It only works with patches introduced in this pull request. The ister.json below is acutally a Jinja2 template, which I render to get the final 'ister.json'. But this is an unimportant detail and I prefer shoing the Jinja2 template because it is more readable than the final result.

```
{
    "DestinationType" : "physical",
    "PartitionLayout" :      [{"disk" : "sda", "partition" : 1, "size"  : "1G",   "type"  : "EFI"},
                              {"disk" : "sda", "partition" : 2, "size"  : "rest", "type"  : "linux"}],
    "FilesystemTypes" :      [{"disk" : "sda", "partition" : 1, "type"  : "vfat", "label" : "boot"},
                              {"disk" : "sda", "partition" : 2, "type"  : "ext4", "label" : "root"}],
    "PartitionMountPoints" : [{"disk" : "sda", "partition" : 1, "mount" : "/boot"},
                              {"disk" : "sda", "partition" : 2, "mount" : "/"}],
    "Hostname"   : "{{ host }}",
    "PostChrootShell" : [{{ "echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config" | tojson}},
                         {{ "echo 'Subsystem sftp /usr/libexec/openssh/sftp-server' >> /etc/ssh/sshd_config" | tojson}}],
    "Users"  :  [{"username" : "root",
                  "password" : {{ rootpass_hash | tojson}},
                  "key" : {{ authkey | tojson }}}],
    "Bundles" : ["kernel-native", "user-basic"],
    "Version" : "latest"
}
```