### PR TITLE
Enhance run command

### DIFF
--- a/ister_test.py
+++ b/ister_test.py
@@ -55,6 +55,7 @@ import tempfile
 import urllib.request as request
 import pycurl
 import netifaces
+import traceback
 import types
 try:
     import pycryptsetup
@@ -5740,13 +5741,15 @@ def run_tests(tests):
             try:
                 test()
             except Exception as exep:
-                print("Test: {0} FAIL: {1}.".format(test.__name__, exep))
-                flog.write("Test: {0} FAIL: {1}.\n".format(test.__name__,
-                                                           exep))
+                msg = "Test: {0} FAIL: {1}.\nHere is the traceback:\n{2}" \
+                      .format(test.__name__, exep, traceback.format_exc())
+                print(msg)
+                flog.write(msg)
                 fail += 1
             else:
-                print("Test: {0} PASS.".format(test.__name__))
-                flog.write("Test: {0} PASS.\n".format(test.__name__))
+                msg = "Test: {0} PASS.".format(test.__name__)
+                print(msg)
+                flog.write(msg)
 
     return fail
 


### PR DESCRIPTION
This pull request includes the other 2 requests I sent earlier - "pylint cleanups" and "changing root user".
I will rebase this pull request f needed later.

This pull request adds these 3 commits:
Enhance run_command()
ister: split run_command()
ister_test: improve tracability

With these changes 'run_command()' is much nicer and now I can actually see 'swupd' progress "real-time":

Running command stdbuf -o 0 swupd verify --install --path=/mnt/sysimage --manifest=latest --contenturl=http://linux-ftp.jf.intel.com/pub/mirrors/clearlinux/update --versionurl=http://linux-ftp.jf.intel.com/pub/mirrors/clearlinux/update --statedir=/var/lib/swupd
Verifying version 25040
Downloading packs...
Extracting bootloader pack for version 24630
Extracting dev-utils pack for version 25040
Extracting git pack for version 25000
Extracting editors pack for version 24950
...

Without this patch we do no see that. Instead, we have a huge delay, and than bulk of output - millions of dots from stdout and then the "Extracting" messages from stderr of swupd.

Enjoy the enhancement. I do enjoy it, at least :)
