### PR TITLE
No default empty password

### DIFF
--- a/ister.py
+++ b/ister.py
@@ -648,22 +648,23 @@ def create_account(user, target_dir):
     """
 
     os.makedirs(target_dir + get_user_homedir(user["username"]), exist_ok=True)
-    if user.get("password"):
-        opts = "-p '{0}'".format(user["password"])
-    else:
-        opts = "-p ''"
+    opts = user["username"]
     if user.get("uid"):
-        opts += " -u {0}".format(user["uid"])
+        opts = "-u {0} ".format(user["uid"]) + opts
+    if "password" in user:
+        opts = "-p '{0}' ".format(user["password"]) + opts
 
-    command = "useradd -U -m {0} {1}".format(opts, user["username"])
+    command = "useradd -U -m {0}".format(opts)
 
     with ChrootOpen(target_dir) as _:
         _, stderr, ret = run_command(command, raise_exception=False)
         if ret == 9:
             # '9' is a documented exit code for the "user already exists" case.
-            # In this case just modify the existing user settings.
-            command = "usermod {0} {1}".format(opts, user["username"])
-            run_command(command)
+            # In this case just modify the existing user settings (if there is
+            # something modify).
+            if opts != user["username"]:
+                command = "usermod {0}".format(opts)
+                run_command(command)
         elif ret != 0 or stderr:
             if stderr:
                 LOG.debug(stderr)

--- a/ister.py
+++ b/ister.py
@@ -665,7 +665,7 @@ def create_account(user, target_dir):
             if opts != user["username"]:
                 command = "usermod {0}".format(opts)
                 run_command(command)
-        elif ret != 0 or stderr:
+        elif ret != 0:
             if stderr:
                 LOG.debug(stderr)
             raise Exception("failed to create user '{0}', 'useradd' returned "

--- a/ister.py
+++ b/ister.py
@@ -1401,7 +1401,6 @@ def download_ister_conf(uri, timeout=15):
                 with closing(os.fdopen(tmpfd, "wb")) as out_file:
                     shutil.copyfileobj(response, out_file)
                     return abs_path
-            os.unlink(abs_path)
         except Exception as err:
             # In a PXE environment it's possible systemd launched us before the
             # network is up. Therefore, keep trying for 'timeout' seconds.

--- a/ister.py
+++ b/ister.py
@@ -1386,10 +1386,14 @@ def validate_template(template):
     LOG.debug(template)
 
 
-def check_kernel_cmdline(f_kcmdline, sleep_time=15):
-    """Check if ister configuration (AKA ister.conf) is defined via kernel
-    command line (PXE environments). If it is defined, then download it and
-    return path to the local copy. Otherwise return 'None'.
+def process_kernel_cmdline(f_kcmdline, sleep_time=15):
+    """Some ister options can be passed via carnel configuration file. For
+    example, 'isterconf=<path>' can be used for passing ister configuration file
+    (AKA 'ister.conf') or ister template file (AKA 'ister.json'). This function
+    processes ister kernel command line options and returns the results.
+
+    If ister.conf/ister.json file was specified, this function downloads it and
+    returns path to a local copy of the file. Otherwise returns 'None'.
     """
     LOG.debug("Inspecting kernel command line for ister.conf location")
     LOG.debug("kernel command line file: {0}".format(f_kcmdline))
@@ -1567,7 +1571,7 @@ def parse_config(args):
     LOG.info("Reading configuration")
     config = {}
 
-    kconf_file = check_kernel_cmdline(args.kcmdline)
+    kconf_file = process_kernel_cmdline(args.kcmdline)
 
     if kconf_file:
         config["template"] = get_template_location(kconf_file)

--- a/ister.py
+++ b/ister.py
@@ -1387,10 +1387,9 @@ def validate_template(template):
 
 
 def check_kernel_cmdline(f_kcmdline, sleep_time=15):
-    """Check if ister.conf defined via kernel command line (pxe envs)
-
-    Kernel command line trumps ister invocation args.
-    Return a tuple (True/False, "path")
+    """Check if ister configuration (AKA ister.conf) is defined via kernel
+    command line (PXE environments). If it is defined, then download it and
+    return path to the local copy. Otherwise return 'None'.
     """
     LOG.debug("Inspecting kernel command line for ister.conf location")
     LOG.debug("kernel command line file: {0}".format(f_kcmdline))
@@ -1415,9 +1414,9 @@ def check_kernel_cmdline(f_kcmdline, sleep_time=15):
         with request.urlopen(ister_conf_uri) as response:
             with closing(os.fdopen(tmpfd, "wb")) as out_file:
                 shutil.copyfileobj(response, out_file)
-                return True, abs_path
+                return abs_path
         os.unlink(abs_path)
-    return False, ''
+    return None
 
 
 def get_host_from_url(url):
@@ -1568,9 +1567,9 @@ def parse_config(args):
     LOG.info("Reading configuration")
     config = {}
 
-    kcmdline, kconf_file = check_kernel_cmdline(args.kcmdline)
+    kconf_file = check_kernel_cmdline(args.kcmdline)
 
-    if kcmdline:
+    if kconf_file:
         config["template"] = get_template_location(kconf_file)
     elif args.config_file:
         config["template"] = get_template_location(args.config_file)

--- a/ister_test.py
+++ b/ister_test.py
@@ -3663,12 +3663,12 @@ def parse_config_good():
         COMMAND_RESULTS.append(path)
         return "http://pxeserver/config.json"
 
-    def mock_process_kernel_cmdline_no(path, sleep_time=1):
+    def mock_process_kernel_cmdline_no(path):
         """mock_process_kernel_cmdline wrapper"""
         # COMMAND_RESULTS.append("no_kcmdline")
         return None
 
-    def mock_process_kernel_cmdline_yes(path, sleep_time=1):
+    def mock_process_kernel_cmdline_yes(path):
         """mock_process_kernel_cmdline wrapper"""
         COMMAND_RESULTS.append(path)
         return "/tmp/abcxyz"
@@ -4015,7 +4015,7 @@ def process_kernel_cmdline_good():
     commands = []
 
     try:
-        ister.process_kernel_cmdline("foo", sleep_time=0)
+        ister.process_kernel_cmdline("foo")
     except Exception as exep:
         raise exep
     finally:
@@ -4061,7 +4061,7 @@ def process_kernel_cmdline_bad_no_isterconf():
     os.unlink = mock_os_unlink
 
     try:
-        ister.process_kernel_cmdline("foo", sleep_time=0)
+        ister.process_kernel_cmdline("foo")
     except Exception as exep:
         raise exep
     finally:
@@ -4105,7 +4105,7 @@ def process_kernel_cmdline_bad_urlopen_fails():
     os.unlink = mock_os_unlink
 
     try:
-        ister.process_kernel_cmdline("foo", sleep_time=0)
+        ister.process_kernel_cmdline("foo")
     except Exception:
         exception_flag = True
     finally:
@@ -4148,7 +4148,7 @@ def process_kernel_cmdline_bad_fdopen_fails():
     os.unlink = mock_os_unlink
 
     try:
-        ister.process_kernel_cmdline("foo", sleep_time=0)
+        ister.process_kernel_cmdline("foo")
     except Exception:
         exception_flag = True
     finally:

--- a/ister_test.py
+++ b/ister_test.py
@@ -3666,12 +3666,12 @@ def parse_config_good():
     def mock_check_kernel_cmdline_no(path, sleep_time=1):
         """mock_check_kernel_cmdline wrapper"""
         # COMMAND_RESULTS.append("no_kcmdline")
-        return False, ""
+        return None
 
     def mock_check_kernel_cmdline_yes(path, sleep_time=1):
         """mock_check_kernel_cmdline wrapper"""
         COMMAND_RESULTS.append(path)
-        return True, "/tmp/abcxyz"
+        return "/tmp/abcxyz"
 
     try:
 

--- a/ister_test.py
+++ b/ister_test.py
@@ -3622,7 +3622,7 @@ def parse_config_good():
     COMMAND_RESULTS = []
     backup_isfile = os.path.isfile
     backup_get_template_location = ister.get_template_location
-    backup_check_kernel_cmdline = ister.check_kernel_cmdline
+    backup_process_kernel_cmdline = ister.process_kernel_cmdline
 
     def mock_isfile_true_etc(path):
         """mock_isfile_true_etc wrapper"""
@@ -3663,13 +3663,13 @@ def parse_config_good():
         COMMAND_RESULTS.append(path)
         return "http://pxeserver/config.json"
 
-    def mock_check_kernel_cmdline_no(path, sleep_time=1):
-        """mock_check_kernel_cmdline wrapper"""
+    def mock_process_kernel_cmdline_no(path, sleep_time=1):
+        """mock_process_kernel_cmdline wrapper"""
         # COMMAND_RESULTS.append("no_kcmdline")
         return None
 
-    def mock_check_kernel_cmdline_yes(path, sleep_time=1):
-        """mock_check_kernel_cmdline wrapper"""
+    def mock_process_kernel_cmdline_yes(path, sleep_time=1):
+        """mock_process_kernel_cmdline wrapper"""
         COMMAND_RESULTS.append(path)
         return "/tmp/abcxyz"
 
@@ -3682,7 +3682,7 @@ def parse_config_good():
         args.config_file = None
         args.template_file = None
         # Check config from kernel command line/network
-        ister.check_kernel_cmdline = mock_check_kernel_cmdline_yes
+        ister.process_kernel_cmdline = mock_process_kernel_cmdline_yes
         ister.get_template_location = mock_get_template_location_tmp
         config = ister.parse_config(args)
         commands = ["/proc/cmdline_yes_ister_conf", "/tmp/abcxyz"]
@@ -3692,7 +3692,7 @@ def parse_config_good():
                             "match expected value")
         # Check config from default ister.conf in etc
         COMMAND_RESULTS = []
-        ister.check_kernel_cmdline = mock_check_kernel_cmdline_no
+        ister.process_kernel_cmdline = mock_process_kernel_cmdline_no
         os.path.isfile = mock_isfile_true_etc
         ister.get_template_location = mock_get_template_location_etc
         config = ister.parse_config(args)
@@ -3735,7 +3735,7 @@ def parse_config_good():
     finally:
         os.path.isfile = backup_isfile
         ister.get_template_location = backup_get_template_location
-        ister.check_kernel_cmdline = backup_check_kernel_cmdline
+        ister.process_kernel_cmdline = backup_process_kernel_cmdline
 
 
 def parse_config_bad():
@@ -3985,7 +3985,7 @@ def validate_network_bad():
 @urlopen_wrapper("good", "baz")
 @fdopen_wrapper("good", "")
 @open_wrapper("good", "bar isterconf=http://localhost/")
-def check_kernel_cmdline_good():
+def process_kernel_cmdline_good():
     """ If isterconf is on kernel command line, detect and fetch
     """
     global COMMAND_RESULTS
@@ -4015,7 +4015,7 @@ def check_kernel_cmdline_good():
     commands = []
 
     try:
-        ister.check_kernel_cmdline("foo", sleep_time=0)
+        ister.process_kernel_cmdline("foo", sleep_time=0)
     except Exception as exep:
         raise exep
     finally:
@@ -4032,7 +4032,7 @@ def check_kernel_cmdline_good():
 @urlopen_wrapper("good", "baz")
 @fdopen_wrapper("good", "")
 @open_wrapper("good", "bar x y z")
-def check_kernel_cmdline_bad_no_isterconf():
+def process_kernel_cmdline_bad_no_isterconf():
     """ If isterconf not on kernel command line, do nothing
     """
     global COMMAND_RESULTS
@@ -4061,7 +4061,7 @@ def check_kernel_cmdline_bad_no_isterconf():
     os.unlink = mock_os_unlink
 
     try:
-        ister.check_kernel_cmdline("foo", sleep_time=0)
+        ister.process_kernel_cmdline("foo", sleep_time=0)
     except Exception as exep:
         raise exep
     finally:
@@ -4076,7 +4076,7 @@ def check_kernel_cmdline_bad_no_isterconf():
 @urlopen_wrapper("bad", "baz")
 @fdopen_wrapper("good", "")
 @open_wrapper("good", "bar isterconf=http://localhost/")
-def check_kernel_cmdline_bad_urlopen_fails():
+def process_kernel_cmdline_bad_urlopen_fails():
     """ If url given to isterconf param is bad, exception is raised.
     """
     global COMMAND_RESULTS
@@ -4105,7 +4105,7 @@ def check_kernel_cmdline_bad_urlopen_fails():
     os.unlink = mock_os_unlink
 
     try:
-        ister.check_kernel_cmdline("foo", sleep_time=0)
+        ister.process_kernel_cmdline("foo", sleep_time=0)
     except Exception:
         exception_flag = True
     finally:
@@ -4119,7 +4119,7 @@ def check_kernel_cmdline_bad_urlopen_fails():
 @urlopen_wrapper("good", "baz")
 @fdopen_wrapper("bad", "")
 @open_wrapper("good", "bar isterconf=http://localhost/")
-def check_kernel_cmdline_bad_fdopen_fails():
+def process_kernel_cmdline_bad_fdopen_fails():
     """ Exception raised if result of mkstemp can't be opened.
     """
     global COMMAND_RESULTS
@@ -4148,7 +4148,7 @@ def check_kernel_cmdline_bad_fdopen_fails():
     os.unlink = mock_os_unlink
 
     try:
-        ister.check_kernel_cmdline("foo", sleep_time=0)
+        ister.process_kernel_cmdline("foo", sleep_time=0)
     except Exception:
         exception_flag = True
     finally:
@@ -5942,10 +5942,10 @@ if __name__ == '__main__':
         parse_config_bad,
         handle_options_good,
         handle_logging_good,
-        check_kernel_cmdline_good,
-        check_kernel_cmdline_bad_no_isterconf,
-        check_kernel_cmdline_bad_urlopen_fails,
-        check_kernel_cmdline_bad_fdopen_fails,
+        process_kernel_cmdline_good,
+        process_kernel_cmdline_bad_no_isterconf,
+        process_kernel_cmdline_bad_urlopen_fails,
+        process_kernel_cmdline_bad_fdopen_fails,
         set_kernel_cmdline_appends_good,
         set_kernel_cmdline_appends_not_in_template,
         get_host_from_url_good_1,

--- a/ister_test.py
+++ b/ister_test.py
@@ -4059,78 +4059,6 @@ def process_kernel_cmdline_bad_no_isterconf():
     commands_compare_helper(commands)
 
 
-@urlopen_wrapper("bad", "baz")
-@fdopen_wrapper("good", "")
-@open_wrapper("good", "bar isterconf=http://localhost/")
-def process_kernel_cmdline_bad_urlopen_fails():
-    """ If url given to isterconf param is bad, exception is raised.
-    """
-    global COMMAND_RESULTS
-    COMMAND_RESULTS = []
-
-    def mock_mkstemp():
-        """ works as intended """
-        COMMAND_RESULTS.append("mkstemp")
-        return 42, "/tmp/xyzzy"
-
-    def mock_copyfileobj(a, b):
-        """ breadcrumbs for file copy """
-        COMMAND_RESULTS.append(a.read())
-        COMMAND_RESULTS.append(b.read())
-
-    mkstemp_orig = tempfile.mkstemp
-    cfo_orig = shutil.copyfileobj
-
-    tempfile.mkstemp = mock_mkstemp
-    shutil.copyfileobj = mock_copyfileobj
-
-    try:
-        ister.process_kernel_cmdline("foo")
-    except Exception:
-        exception_flag = True
-    finally:
-        tempfile.mkstemp = mkstemp_orig
-        shutil.copyfileobj = cfo_orig
-    if not exception_flag:
-        raise Exception("Failed to fail getting bad url")
-
-
-@urlopen_wrapper("good", "baz")
-@fdopen_wrapper("bad", "")
-@open_wrapper("good", "bar isterconf=http://localhost/")
-def process_kernel_cmdline_bad_fdopen_fails():
-    """ Exception raised if result of mkstemp can't be opened.
-    """
-    global COMMAND_RESULTS
-    COMMAND_RESULTS = []
-
-    def mock_mkstemp():
-        """ works as intended """
-        COMMAND_RESULTS.append("mkstemp")
-        return 42, "/tmp/xyzzy"
-
-    def mock_copyfileobj(a, b):
-        """ breadcrumbs for file copy """
-        COMMAND_RESULTS.append(a.read())
-        COMMAND_RESULTS.append(b.read())
-
-    mkstemp_orig = tempfile.mkstemp
-    cfo_orig = shutil.copyfileobj
-
-    tempfile.mkstemp = mock_mkstemp
-    shutil.copyfileobj = mock_copyfileobj
-
-    try:
-        ister.process_kernel_cmdline("foo")
-    except Exception:
-        exception_flag = True
-    finally:
-        tempfile.mkstemp = mkstemp_orig
-        shutil.copyfileobj = cfo_orig
-    if not exception_flag:
-        raise Exception("Failed to fail on fdopen")
-
-
 @run_command_wrapper
 @open_wrapper("good", "")
 def set_kernel_cmdline_appends_good():
@@ -5916,8 +5844,6 @@ if __name__ == '__main__':
         handle_logging_good,
         process_kernel_cmdline_good,
         process_kernel_cmdline_bad_no_isterconf,
-        process_kernel_cmdline_bad_urlopen_fails,
-        process_kernel_cmdline_bad_fdopen_fails,
         set_kernel_cmdline_appends_good,
         set_kernel_cmdline_appends_not_in_template,
         get_host_from_url_good_1,

--- a/ister_test.py
+++ b/ister_test.py
@@ -1919,17 +1919,34 @@ def chroot_open_class_bad_close():
 def create_account_good():
     """Create account no uid"""
     template = {"username": "user"}
-    commands = ["useradd -U -m -p '' user", False]
+    commands = ["useradd -U -m user", False]
     ister.create_account(template, "/tmp")
     commands_compare_helper(commands)
 
+@run_command_wrapper
+@chroot_open_wrapper("silent")
+def create_account_good_pass():
+    """Create account no uid"""
+    template = {"username": "user", "password" : "pass"}
+    commands = ["useradd -U -m -p 'pass' user", False]
+    ister.create_account(template, "/tmp")
+    commands_compare_helper(commands)
+
+@run_command_wrapper
+@chroot_open_wrapper("silent")
+def create_account_good_empty_pass():
+    """Create account no uid"""
+    template = {"username": "user", "password" : ""}
+    commands = ["useradd -U -m -p '' user", False]
+    ister.create_account(template, "/tmp")
+    commands_compare_helper(commands)
 
 @run_command_wrapper
 @chroot_open_wrapper("silent")
 def create_account_good_uid():
     """Create account with uid"""
     template = {"username": "user", "uid": "1000"}
-    commands = ["useradd -U -m -p '' -u 1000 user", False]
+    commands = ["useradd -U -m -u 1000 user", False]
     ister.create_account(template, "/tmp")
     commands_compare_helper(commands)
 
@@ -1946,8 +1963,8 @@ def create_account_existing():
 
     ister.run_command = mock_run_command
     template = {"username": "user", "uid": "1000"}
-    commands = ["useradd -U -m -p '' -u 1000 user", False,
-                "usermod -p '' -u 1000 user"]
+    commands = ["useradd -U -m -u 1000 user", False,
+                "usermod -u 1000 user"]
     ister.create_account(template, "/tmp")
     commands_compare_helper(commands)
     ister.run_command = backup_run_command
@@ -5729,6 +5746,8 @@ if __name__ == '__main__':
         chroot_open_class_bad_chdir,
         chroot_open_class_bad_close,
         create_account_good,
+        create_account_good_pass,
+        create_account_good_empty_pass,
         create_account_good_uid,
         create_account_existing,
         add_user_key_good,

--- a/ister_test.py
+++ b/ister_test.py
@@ -4001,17 +4001,11 @@ def process_kernel_cmdline_good():
         COMMAND_RESULTS.append(a.read())
         COMMAND_RESULTS.append(b.read())
 
-    def mock_os_unlink(path):
-        """ breadcrumb for os.unlink """
-        COMMAND_RESULTS.append("unlink_{0}".format(path))
-
     mkstemp_orig = tempfile.mkstemp
     cfo_orig = shutil.copyfileobj
-    unlink_orig = os.unlink
 
     tempfile.mkstemp = mock_mkstemp
     shutil.copyfileobj = mock_copyfileobj
-    os.unlink = mock_os_unlink
     commands = []
 
     try:
@@ -4021,7 +4015,6 @@ def process_kernel_cmdline_good():
     finally:
         tempfile.mkstemp = mkstemp_orig
         shutil.copyfileobj = cfo_orig
-        os.unlink = unlink_orig
 
     commands = ['foo', 'r', 'read', 'mkstemp',
                 'http://localhost/', 42, 'wb', 'read',
@@ -4048,17 +4041,11 @@ def process_kernel_cmdline_bad_no_isterconf():
         COMMAND_RESULTS.append(a.read())
         COMMAND_RESULTS.append(b.read())
 
-    def mock_os_unlink(path):
-        """ breadcrumb for os.unlink """
-        COMMAND_RESULTS.append("unlink_{0}".format(path))
-
     mkstemp_orig = tempfile.mkstemp
     cfo_orig = shutil.copyfileobj
-    unlink_orig = os.unlink
 
     tempfile.mkstemp = mock_mkstemp
     shutil.copyfileobj = mock_copyfileobj
-    os.unlink = mock_os_unlink
 
     try:
         ister.process_kernel_cmdline("foo")
@@ -4067,7 +4054,6 @@ def process_kernel_cmdline_bad_no_isterconf():
     finally:
         tempfile.mkstemp = mkstemp_orig
         shutil.copyfileobj = cfo_orig
-        os.unlink = unlink_orig
 
     commands = ['foo', 'r', 'read']
     commands_compare_helper(commands)
@@ -4092,17 +4078,11 @@ def process_kernel_cmdline_bad_urlopen_fails():
         COMMAND_RESULTS.append(a.read())
         COMMAND_RESULTS.append(b.read())
 
-    def mock_os_unlink(path):
-        """ breadcrumb for os.unlink """
-        COMMAND_RESULTS.append("unlink_{0}".format(path))
-
     mkstemp_orig = tempfile.mkstemp
     cfo_orig = shutil.copyfileobj
-    unlink_orig = os.unlink
 
     tempfile.mkstemp = mock_mkstemp
     shutil.copyfileobj = mock_copyfileobj
-    os.unlink = mock_os_unlink
 
     try:
         ister.process_kernel_cmdline("foo")
@@ -4111,7 +4091,6 @@ def process_kernel_cmdline_bad_urlopen_fails():
     finally:
         tempfile.mkstemp = mkstemp_orig
         shutil.copyfileobj = cfo_orig
-        os.unlink = unlink_orig
     if not exception_flag:
         raise Exception("Failed to fail getting bad url")
 
@@ -4135,17 +4114,11 @@ def process_kernel_cmdline_bad_fdopen_fails():
         COMMAND_RESULTS.append(a.read())
         COMMAND_RESULTS.append(b.read())
 
-    def mock_os_unlink(path):
-        """ breadcrumb for os.unlink """
-        COMMAND_RESULTS.append("unlink_{0}".format(path))
-
     mkstemp_orig = tempfile.mkstemp
     cfo_orig = shutil.copyfileobj
-    unlink_orig = os.unlink
 
     tempfile.mkstemp = mock_mkstemp
     shutil.copyfileobj = mock_copyfileobj
-    os.unlink = mock_os_unlink
 
     try:
         ister.process_kernel_cmdline("foo")
@@ -4154,7 +4127,6 @@ def process_kernel_cmdline_bad_fdopen_fails():
     finally:
         tempfile.mkstemp = mkstemp_orig
         shutil.copyfileobj = cfo_orig
-        os.unlink = unlink_orig
     if not exception_flag:
         raise Exception("Failed to fail on fdopen")
 


### PR DESCRIPTION
This pull request is on top of the "Remove 15 secs sleep". Please, review/pull this request after "Remove 15 secs sleep".

This pull request addresses the issue you spotted while reviewing one of my previous pull requests: if user password is not specified, we create the user with an empty password, and this is poor choice for the default password from security point of view. This is not something I introduced, this behavior existed for long time, and I hope changing it won't break users. But it is better to change now than later.

With this pull request if the password was not specify, we just create the user without any password and using this user to log in will be prohibited. Compare this to the old behavior, where we use empty password and anyone can login.
