### PR TITLE
Reboot only on success

### DIFF
--- a/ister-provision.service
+++ b/ister-provision.service
@@ -3,8 +3,7 @@ Description=ister graphical installer
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/python3 /usr/bin/ister.py
-ExecStartPost=/usr/sbin/reboot
+ExecStart=/bin/sh -c '/usr/bin/python3 /usr/bin/ister.py && /usr/sbin/reboot'
 
 [Install]
 WantedBy=multi-user.target

--- a/ister.py
+++ b/ister.py
@@ -1455,13 +1455,9 @@ def process_kernel_cmdline(f_kcmdline):
         # Handle the "root_ssh" option first enable root login ASAP.
         enable_root_ssh_login()
     if "ister.exit" in kernel_args:
-        LOG.debug("exiting due to 'ister.exit' found in kernel command line")
-        # We really should just exit here, but unfortunately today ClearLinux
-        # PXE installer image will reboot immediately. Let's just sleep forever
-        # as a temporary workaround, until we find a better way.
-        # raise SystemExit(0)
-        while True:
-            time.sleep(0xFFFFFFFF)
+        LOG.info("exiting with status 13 due to 'ister.exit' found in kernel "
+                 "command line")
+        raise SystemExit(13)
     for opt in kernel_args:
         if opt.startswith("isterconf="):
             ister_conf_uri = opt.split("=")[1]

--- a/ister.service
+++ b/ister.service
@@ -3,8 +3,7 @@ Description=ister graphical installer
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/python3 /usr/bin/ister_gui.py
-ExecStartPost=/usr/sbin/reboot
+ExecStart=/bin/sh -c '/usr/bin/python3 /usr/bin/ister_gui.py && /usr/sbin/reboot'
 StandardInput=tty
 StandardOutput=tty
 StandardError=tty


### PR DESCRIPTION
Do not reboot the system is ister failed. Improve the 'ister.exit' option handling.